### PR TITLE
Feature/009 아이템 도메인 구현

### DIFF
--- a/src/main/java/com/devlop/siren/item/domain/Allergy.java
+++ b/src/main/java/com/devlop/siren/item/domain/Allergy.java
@@ -34,7 +34,7 @@ public enum Allergy {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    public static String convertToString(EnumSet<Allergy> allergies){
+    public static String convertToString(EnumSet<Allergy> allergies) {
         if (allergies.isEmpty() || allergies == null) {
             return "";
         }

--- a/src/main/java/com/devlop/siren/item/domain/Allergy.java
+++ b/src/main/java/com/devlop/siren/item/domain/Allergy.java
@@ -1,0 +1,46 @@
+package com.devlop.siren.item.domain;
+
+import lombok.Getter;
+import org.apache.logging.log4j.util.Strings;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public enum Allergy {
+    MILK("우유"),
+    SOYBEAN("대두"),
+    WHEAT("밀"),
+    PEANUT("땅콩"),
+    TOMATO("토마토"),
+    PEACH("복숭아"),
+    SQUID("오징어");
+
+    private final String allergyName;
+
+    Allergy(String allergyName) {
+        this.allergyName = allergyName;
+    }
+
+
+    public static EnumSet<Allergy> convertToEnumSet(String allergy) {
+        if (Strings.isEmpty(allergy)) {
+            return EnumSet.noneOf(Allergy.class);
+        }
+        return (EnumSet<Allergy>) Arrays.stream(allergy.split(","))
+                .map(name -> Allergy.valueOf(allergy))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public static String convertToString(EnumSet<Allergy> allergies){
+        if (allergies.isEmpty() || allergies == null) {
+            return "";
+        }
+        List<String> allergy = allergies.stream()
+                .map(Enum::name)
+                .collect(Collectors.toUnmodifiableList());
+        return String.join(",", allergy);
+    }
+}

--- a/src/main/java/com/devlop/siren/item/domain/Category.java
+++ b/src/main/java/com/devlop/siren/item/domain/Category.java
@@ -1,0 +1,37 @@
+package com.devlop.siren.item.domain;
+
+import com.devlop.siren.item.dto.CategoryCreateRequest;
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "category")
+@Getter
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(name = "category_name")
+    @NotNull
+    private String categoryName;
+
+    @Column(name = "category_type")
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private CategoryType categoryType;
+
+    @Builder
+    public Category(String categoryName, CategoryType categoryType){
+        this.categoryName = categoryName;
+        this.categoryType = categoryType;
+    }
+
+    public void update(CategoryCreateRequest categoryCreateRequest){
+        this.categoryName = categoryCreateRequest.getCategoryName();
+        this.categoryType = categoryCreateRequest.getCategoryType();
+    }
+}

--- a/src/main/java/com/devlop/siren/item/domain/Category.java
+++ b/src/main/java/com/devlop/siren/item/domain/Category.java
@@ -1,7 +1,10 @@
 package com.devlop.siren.item.domain;
 
 import com.devlop.siren.item.dto.CategoryCreateRequest;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -25,12 +28,12 @@ public class Category {
     private CategoryType categoryType;
 
     @Builder
-    public Category(String categoryName, CategoryType categoryType){
+    public Category(String categoryName, CategoryType categoryType) {
         this.categoryName = categoryName;
         this.categoryType = categoryType;
     }
 
-    public void update(CategoryCreateRequest categoryCreateRequest){
+    public void update(CategoryCreateRequest categoryCreateRequest) {
         this.categoryName = categoryCreateRequest.getCategoryName();
         this.categoryType = categoryCreateRequest.getCategoryType();
     }

--- a/src/main/java/com/devlop/siren/item/domain/CategoryType.java
+++ b/src/main/java/com/devlop/siren/item/domain/CategoryType.java
@@ -1,0 +1,27 @@
+package com.devlop.siren.item.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Getter
+public enum CategoryType {
+    BEVERAGE("음료"),
+    FOOD("푸드"),
+    PRODUCT("상품");
+
+    private final String name;
+
+    CategoryType(String name) {
+        this.name = name;
+    }
+
+    @JsonCreator
+    public static CategoryType of(String typeName){
+        return Arrays.stream(values())
+                .filter(categoryType -> Objects.equals(categoryType.name(), typeName))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리 타입 입니다."));
+    }
+}

--- a/src/main/java/com/devlop/siren/item/domain/CategoryType.java
+++ b/src/main/java/com/devlop/siren/item/domain/CategoryType.java
@@ -19,7 +19,7 @@ public enum CategoryType {
     }
 
     @JsonCreator
-    public static CategoryType of(String typeName){
+    public static CategoryType of(String typeName) {
         return Arrays.stream(values())
                 .filter(categoryType -> Objects.equals(categoryType.name(), typeName))
                 .findFirst().orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리 타입 입니다."));

--- a/src/main/java/com/devlop/siren/item/domain/DefaultOption.java
+++ b/src/main/java/com/devlop/siren/item/domain/DefaultOption.java
@@ -1,12 +1,13 @@
 package com.devlop.siren.item.domain;
 
-import java.util.Objects;
+import com.devlop.siren.item.dto.DefaultOptionCreateRequest;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-
-import com.devlop.siren.item.dto.DefaultOptionCreateRequest;
-import lombok.*;
 
 @Table(name = "default_options")
 @Entity
@@ -52,7 +53,7 @@ public class DefaultOption {
         this.hazelnutSyrupCount = this.hazelnutSyrupCount == null ? 0 : this.hazelnutSyrupCount;
     }
 
-    public void update(DefaultOptionCreateRequest defaultOptionCreateRequest){
+    public void update(DefaultOptionCreateRequest defaultOptionCreateRequest) {
         this.espressoShotCount = defaultOptionCreateRequest.getEspressoShotCount();
         this.vanillaSyrupCount = defaultOptionCreateRequest.getVanillaSyrupCount();
         this.caramelSyrupCount = defaultOptionCreateRequest.getCaramelSyrupCount();

--- a/src/main/java/com/devlop/siren/item/domain/DefaultOption.java
+++ b/src/main/java/com/devlop/siren/item/domain/DefaultOption.java
@@ -1,0 +1,63 @@
+package com.devlop.siren.item.domain;
+
+import java.util.Objects;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import com.devlop.siren.item.dto.DefaultOptionCreateRequest;
+import lombok.*;
+
+@Table(name = "default_options")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DefaultOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long defaultOptionId;
+
+    @Column(name = "espresso_shot_count", columnDefinition = "TINYINT")
+    private Integer espressoShotCount;
+
+    @Column(name = "vanilla_syrup_count", columnDefinition = "TINYINT")
+    private Integer vanillaSyrupCount;
+
+    @Column(name = "caramel_syrup_count", columnDefinition = "TINYINT")
+    private Integer caramelSyrupCount;
+
+    @Column(name = "hazelnut_syrup_count", columnDefinition = "TINYINT")
+    private Integer hazelnutSyrupCount;
+
+    @Column(name = "size")
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private SizeType size;
+
+    @Builder
+    public DefaultOption(Integer espressoShotCount, Integer vanillaSyrupCount, Integer caramelSyrupCount, Integer hazelnutSyrupCount, SizeType size) {
+        this.espressoShotCount = espressoShotCount;
+        this.vanillaSyrupCount = vanillaSyrupCount;
+        this.caramelSyrupCount = caramelSyrupCount;
+        this.hazelnutSyrupCount = hazelnutSyrupCount;
+        this.size = size;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.espressoShotCount = this.espressoShotCount == null ? 0 : this.espressoShotCount;
+        this.vanillaSyrupCount = this.vanillaSyrupCount == null ? 0 : this.vanillaSyrupCount;
+        this.caramelSyrupCount = this.caramelSyrupCount == null ? 0 : this.vanillaSyrupCount;
+        this.hazelnutSyrupCount = this.hazelnutSyrupCount == null ? 0 : this.hazelnutSyrupCount;
+    }
+
+    public void update(DefaultOptionCreateRequest defaultOptionCreateRequest){
+        this.espressoShotCount = defaultOptionCreateRequest.getEspressoShotCount();
+        this.vanillaSyrupCount = defaultOptionCreateRequest.getVanillaSyrupCount();
+        this.caramelSyrupCount = defaultOptionCreateRequest.getCaramelSyrupCount();
+        this.hazelnutSyrupCount = defaultOptionCreateRequest.getHazelnutSyrupCount();
+        this.size = defaultOptionCreateRequest.getSize();
+    }
+
+}

--- a/src/main/java/com/devlop/siren/item/domain/Item.java
+++ b/src/main/java/com/devlop/siren/item/domain/Item.java
@@ -1,0 +1,91 @@
+package com.devlop.siren.item.domain;
+
+import com.devlop.siren.item.dto.ItemCreateRequest;
+import com.devlop.siren.item.utils.AllergyConverter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.EnumSet;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "items")
+@Getter
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long itemId;
+
+    @NotNull
+    @Column(name = "item_name", columnDefinition = "NVARCHAR(255)")
+    private String itemName;
+
+    @NotNull
+    @Column(name = "price")
+    private Integer price;
+
+    @NotNull
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "stock")
+    private Integer stock;
+
+    @Column(name = "image")
+    private String image;
+
+
+    @Column(name = "is_best", columnDefinition = "TINYINT(1)")
+    private Boolean isBest;
+
+    @Column(name = "is_new", columnDefinition = "TINYINT(1)")
+    private Boolean isNew;
+
+    @Column(name = "allergy")
+    @Convert(converter = AllergyConverter.class)
+    private EnumSet<Allergy> allergies;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "default_option_id")
+    private DefaultOption defaultOption;
+
+    @PrePersist
+    public void prePersist() {
+        this.isBest = this.isBest != null && this.isBest;
+        this.isNew = this.isNew != null && this.isNew;
+        this.stock = this.stock == null ? 0 : this.stock;
+    }
+
+    @Builder
+    public Item(String itemName, Integer price, String description, Integer stock, String image, Boolean isBest, Boolean isNew, EnumSet<Allergy> allergies, Category category, DefaultOption defaultOption) {
+        this.itemName = itemName;
+        this.price = price;
+        this.description = description;
+        this.stock = stock;
+        this.image = image;
+        this.isBest = isBest;
+        this.isNew = isNew;
+        this.allergies = allergies;
+        this.category = category;
+        this.defaultOption = defaultOption;
+    }
+
+    public void update(ItemCreateRequest itemCreateRequest) {
+        this.itemName = itemCreateRequest.getItemName();
+        this.price = itemCreateRequest.getPrice();
+        this.description = itemCreateRequest.getDescription();
+        this.stock = itemCreateRequest.getStock();
+        this.image = itemCreateRequest.getImage();
+        this.isBest = itemCreateRequest.getIsBest();
+        this.isNew = itemCreateRequest.getIsNew();
+        this.allergies = Allergy.convertToEnumSet(itemCreateRequest.getAllergy());
+    }
+}

--- a/src/main/java/com/devlop/siren/item/domain/SizeType.java
+++ b/src/main/java/com/devlop/siren/item/domain/SizeType.java
@@ -1,0 +1,30 @@
+package com.devlop.siren.item.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Getter
+public enum SizeType {
+    TALL("Tall", "355ml"),
+    GRANDE("Grande", "473ml"),
+    VENTI("Venti", "591ml"),
+    TRENTA("Trenta", "887ml");
+
+    private final String englishName;
+    private final String amount;
+
+    SizeType(String englishName, String amount) {
+        this.amount = amount;
+        this.englishName = englishName;
+    }
+
+    @JsonCreator
+    public static SizeType of(String size) {
+        return Arrays.stream(values())
+                .filter(sizeType -> Objects.equals(sizeType.englishName, size))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사이즈입니다."));
+    }
+}


### PR DESCRIPTION
## 🎯 What is this PR
- 아이템 도메인 구현(영양정보 제외한)

## 📄 Changes Made
- 아이템 엔티티 구현
- 카테고리 엔티티 구현
- 디폴트 옵션 엔티티 구현
- 알러지 객체 구현
- 카테고리 타입 객체 구현
- 컵사이즈 객체 구현

## 📸 Screenshot
> 스크린 샷 첨부

## 🙋🏻‍ Review Point
- Entity의 수정이 일어났을때 `@Setter` 를 사용하지 않고 `update` 메서드로 구성했을 시 <br> 전체 필드들의 내용을 모두 입력하여 수정하는 방법이 최선일까?
- `DefaultOption.class`를 예롤 들자면 사용자가 값을 입력하지 않았을 때 default값이 DB에 들어갈 수 있게 prePersist 메서드를 사용하였는데<br> prePersist메서드를 사용하는 것과 단순하게 `DefaultOption.class`에 검증 메서드(`validXXX()`)를 추가하는것중 무엇이 더 괜찮은 판단일까?
- image 처리 방법 논의
- **Entity를 구성할수록 item이 stock을 가지고 있는것이 너무 이상해보여 stock필드의 존재성 논의**
- **컵 사이즈 객체의 위치 논의**
- 검증로직을 DTO에만 추가하는것이 아닌 Entity에도 추가하는것이 옳은 판단일지 논의

## ✅ Test Checklist
- [ ] 완료한 테스트 내용 작성

## 🔗 Reference
Issue #9