### PR TITLE
아이템, 카테고리 인증정보 구현

### DIFF
--- a/src/main/java/com/devlop/siren/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/devlop/siren/domain/category/controller/CategoryController.java
@@ -6,9 +6,12 @@ import com.devlop.siren.domain.category.dto.response.CategoriesResponse;
 import com.devlop.siren.domain.category.dto.response.CategoryResponse;
 import com.devlop.siren.domain.category.entity.CategoryType;
 import com.devlop.siren.domain.category.service.CategoryService;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
 import com.devlop.siren.global.common.response.ApiResponse;
 import com.devlop.siren.global.common.response.ResponseCode;
+import com.devlop.siren.global.util.UserInformation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,7 +28,8 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @PostMapping
-    public ApiResponse<CategoryResponse> createCategory(@RequestBody @Valid CategoryCreateRequest categoryCreateRequest) {
+    public ApiResponse<CategoryResponse> createCategory(@RequestBody @Valid CategoryCreateRequest categoryCreateRequest, @AuthenticationPrincipal UserDetailsDto user) {
+        UserInformation.validAdmin(user);
         CategoryResponse categoryResponse = categoryService.register(categoryCreateRequest);
         return ApiResponse.ok(ResponseCode.Normal.CREATE, categoryResponse);
     }

--- a/src/main/java/com/devlop/siren/domain/item/controller/ItemController.java
+++ b/src/main/java/com/devlop/siren/domain/item/controller/ItemController.java
@@ -6,9 +6,12 @@ import com.devlop.siren.domain.item.dto.response.ItemDetailResponse;
 import com.devlop.siren.domain.item.dto.response.ItemResponse;
 import com.devlop.siren.domain.item.dto.response.NutritionDetailResponse;
 import com.devlop.siren.domain.item.service.ItemService;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
 import com.devlop.siren.global.common.response.ApiResponse;
 import com.devlop.siren.global.common.response.ResponseCode;
+import com.devlop.siren.global.util.UserInformation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,8 +27,8 @@ public class ItemController {
     private final ItemService itemService;
 
     @PostMapping
-    public ApiResponse<ItemResponse> createItem(@RequestBody @Valid ItemCreateRequest itemCreateRequest) {
-
+    public ApiResponse<ItemResponse> createItem(@RequestBody @Valid ItemCreateRequest itemCreateRequest, @AuthenticationPrincipal UserDetailsDto user) {
+        UserInformation.validAdmin(user);
         return ApiResponse.ok(ResponseCode.Normal.CREATE, itemService.create(itemCreateRequest));
     }
 
@@ -48,13 +51,15 @@ public class ItemController {
     }
 
     @DeleteMapping(value = "/{itemId}")
-    public ApiResponse<?> deleteItem(@PathVariable @Min(1L) Long itemId) {
+    public ApiResponse<?> deleteItem(@PathVariable @Min(1L) Long itemId, @AuthenticationPrincipal UserDetailsDto user) {
+        UserInformation.validAdmin(user);
         Long id = itemService.deleteItemById(itemId);
         return ApiResponse.ok(ResponseCode.Normal.DELETE, String.format("ItemId = %d", id));
     }
 
     @PutMapping(value = "/{itemId}")
-    public ApiResponse<?> updateItem(@PathVariable @Min(1L) Long itemId, @RequestBody @Valid ItemCreateRequest itemCreateRequest) {
+    public ApiResponse<?> updateItem(@PathVariable @Min(1L) Long itemId, @RequestBody @Valid ItemCreateRequest itemCreateRequest, @AuthenticationPrincipal UserDetailsDto user) {
+        UserInformation.validAdmin(user);
         Long id = itemService.updateItemById(itemId, itemCreateRequest);
         return ApiResponse.ok(ResponseCode.Normal.UPDATE, String.format("ItemId = %d", id));
     }

--- a/src/main/java/com/devlop/siren/global/common/response/ResponseCode.java
+++ b/src/main/java/com/devlop/siren/global/common/response/ResponseCode.java
@@ -29,7 +29,8 @@ public class ResponseCode {
         INVALID_SIZE_TYPE(HttpStatus.BAD_REQUEST, "적합하지 않은 컵 사이즈 타입입니다"),
         NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "해당하는 카테고리를 찾을 수 없습니다"),
         NOT_FOUND_ITEM(HttpStatus.NOT_FOUND, "해당하는 아이템을 찾을 수 없습니다"),
-        NOT_VALID(HttpStatus.NOT_ACCEPTABLE, "적합하지 않은 입력입니다");
+        NOT_VALID(HttpStatus.NOT_ACCEPTABLE, "적합하지 않은 입력입니다"),
+        NOT_AUTHORITY_USER(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다");
 
 
         private final HttpStatus status;

--- a/src/main/java/com/devlop/siren/global/util/UserInformation.java
+++ b/src/main/java/com/devlop/siren/global/util/UserInformation.java
@@ -1,0 +1,16 @@
+package com.devlop.siren.global.util;
+
+
+import com.devlop.siren.domain.user.domain.UserRole;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.global.common.response.ResponseCode;
+import com.devlop.siren.global.exception.GlobalException;
+
+public class UserInformation {
+    public static boolean validAdmin(UserDetailsDto user) {
+        if (!user.getUserRole().equals(UserRole.ADMIN)) {
+            throw new GlobalException(ResponseCode.ErrorCode.NOT_AUTHORITY_USER);
+        }
+        return true;
+    }
+}

--- a/src/test/java/com/devlop/siren/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/devlop/siren/category/controller/CategoryControllerTest.java
@@ -4,20 +4,26 @@ import com.devlop.siren.domain.category.controller.CategoryController;
 import com.devlop.siren.domain.category.dto.request.CategoryCreateRequest;
 import com.devlop.siren.domain.category.entity.CategoryType;
 import com.devlop.siren.domain.category.service.CategoryService;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.global.util.UserInformation;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,11 +43,18 @@ class CategoryControllerTest {
     private ObjectMapper objectMapper;
     static CategoryCreateRequest validObject;
     static CategoryCreateRequest inValidObject;
+    private static MockedStatic<UserInformation> userInformationMock;
 
     @BeforeAll
     private static void setUp() {
         validObject = new CategoryCreateRequest(CategoryType.BEVERAGE, "에스프레소");
         inValidObject = new CategoryCreateRequest(CategoryType.BEVERAGE, " ");
+        userInformationMock = mockStatic(UserInformation.class);
+    }
+
+    @AfterAll
+    private static void cleanUp() {
+        userInformationMock.close();
     }
 
     @Test
@@ -50,6 +63,7 @@ class CategoryControllerTest {
     void createCategory() throws Exception {
         //given
         //when
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         //then
         mvc.perform(post("/api/categories")
                         .with(csrf())

--- a/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
@@ -11,7 +11,6 @@ import com.devlop.siren.domain.item.service.ItemService;
 import com.devlop.siren.domain.user.dto.UserDetailsDto;
 import com.devlop.siren.global.util.UserInformation;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.After;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -19,11 +18,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -65,9 +62,10 @@ class ItemControllerTest {
     }
 
     @AfterAll
-    private static void cleanUp(){
+    private static void cleanUp() {
         userInformationMock.close();
     }
+
     @Test
     @DisplayName("Valid 조건에 맞는 파라미터를 넘기면 아이템 생성에 성공한다 - DTO 검증")
     @WithMockUser
@@ -153,7 +151,7 @@ class ItemControllerTest {
     void deleteItem(Long itemId) throws Exception {
         when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         mvc.perform(delete("/api/items/{itemId}", itemId)
-                .with(csrf()))
+                        .with(csrf()))
                 .andExpect(status().isOk())
                 .andDo(print());
     }

--- a/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
@@ -8,12 +8,18 @@ import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
 import com.devlop.siren.domain.item.dto.request.NutritionCreateRequest;
 import com.devlop.siren.domain.item.entity.SizeType;
 import com.devlop.siren.domain.item.service.ItemService;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.global.util.UserInformation;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,6 +28,9 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -40,6 +49,7 @@ class ItemControllerTest {
     private ObjectMapper objectMapper;
     static ItemCreateRequest validObject;
     static ItemCreateRequest inValidObject;
+    private static MockedStatic<UserInformation> userInformationMock;
 
     @BeforeAll
     private static void setUp() {
@@ -51,15 +61,20 @@ class ItemControllerTest {
                 , "아메리카노"
                 , -5, "아메리카노입니다", null, false, true,
                 new DefaultOptionCreateRequest(2, 0, 0, 0, SizeType.of("Tall")), "우유, 대두", new NutritionCreateRequest(0, 2, 3, 0, 1, 2, 2, 0, 0, 0));
-
+        userInformationMock = mockStatic(UserInformation.class);
     }
 
+    @AfterAll
+    private static void cleanUp(){
+        userInformationMock.close();
+    }
     @Test
     @DisplayName("Valid 조건에 맞는 파라미터를 넘기면 아이템 생성에 성공한다 - DTO 검증")
     @WithMockUser
     void createItem() throws Exception {
         //given
         //when
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         //then
         mvc.perform(post("/api/items")
                         .with(csrf())
@@ -136,7 +151,9 @@ class ItemControllerTest {
     @DisplayName("Valid 조건에 맞는 파라미터를 넘기면 아이템 삭제에 성공한다 - DTO 검증")
     @WithMockUser
     void deleteItem(Long itemId) throws Exception {
-        mvc.perform(get("/api/items/{itemId}", itemId))
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
+        mvc.perform(delete("/api/items/{itemId}", itemId)
+                .with(csrf()))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -146,6 +163,7 @@ class ItemControllerTest {
     @DisplayName("Invalid 조건에 맞는 파라미터를 넘기면 아이템 삭제에 실패한다 - DTO 검증")
     @WithMockUser
     void inValidDeleteItem(Long itemId) throws Exception {
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         mvc.perform(delete("/api/items/{itemId}", itemId)
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
@@ -157,6 +175,7 @@ class ItemControllerTest {
     @DisplayName("Valid 조건에 맞는 파라미터를 넘기면 아이템 수정에 성공한다 - DTO 검증")
     @WithMockUser
     void updateItem(Long itemId) throws Exception {
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         mvc.perform(put("/api/items/{itemId}", itemId)
                         .with(csrf())
                         .content(objectMapper.writeValueAsString(validObject))
@@ -168,9 +187,10 @@ class ItemControllerTest {
 
     @ParameterizedTest
     @ValueSource(longs = {-1L, 0L})
-    @DisplayName("Invalid 조건에 맞는 파라미터를 넘기면 아이템 삭제에 실패한다 - DTO 검증")
+    @DisplayName("Invalid 조건에 맞는 파라미터를 넘기면 아이템 수정에 실패한다 - DTO 검증")
     @WithMockUser
     void inValidUpdateItem(Long itemId) throws Exception {
+        when(UserInformation.validAdmin(any(UserDetailsDto.class))).thenReturn(true);
         mvc.perform((put("/api/items/{itemId}", itemId)
                         .with(csrf())
                         .content(objectMapper.writeValueAsString(inValidObject))


### PR DESCRIPTION
## 🎯 What is this PR
아이템과 카테고리에 User를 검증하는 부분 추가

## 📄 Changes Made
- UserInformation.class 가 static메서드로 User를 검증하는 메서드를 가져<br> 하나의 메서드로 매장, 아이템, 카테고리까지 모두 검증할 수 있게 구성

## 📸 Screenshot

<img width="1031" alt="스크린샷 2023-10-20 오후 7 48 07" src="https://github.com/Siren-repo/Siren/assets/98626972/0407f4cb-a1ed-49b6-929a-64d242375e53">

<img width="1031" alt="스크린샷 2023-10-20 오후 7 47 55" src="https://github.com/Siren-repo/Siren/assets/98626972/3bfbbaa4-efbb-452a-8343-e713e15f0460">

### ADMIN 권한을 가진 사용자
![image](https://github.com/Siren-repo/Siren/assets/98626972/7b152eca-9e23-432a-99e5-d1eaa1021c7c)

### ADMIN 권한이 없는 사용자
![image](https://github.com/Siren-repo/Siren/assets/98626972/44eb7899-6ab8-414d-a2f4-d51ef8a45a70)


## 🙋🏻‍ Review Point
- UserInformation.class의 메서드 부분
- Test 구성할때 static메서드를 사용해서 추가한 부분(@BeforeAll, @AfterAll 에서 할당과 해제 부분)

## ✅ Test Checklist
- [x] ItemControllerTest
- [x] CategoryControllerTest

## 🔗 Reference
Issue #19