### PR TITLE
주문 관련 엔티티 구현 

### DIFF
--- a/src/main/java/com/devlop/siren/domain/item/dto/request/DefaultOptionCreateRequest.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/request/DefaultOptionCreateRequest.java
@@ -1,7 +1,7 @@
 package com.devlop.siren.domain.item.dto.request;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/devlop/siren/domain/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/request/ItemCreateRequest.java
@@ -4,7 +4,7 @@ package com.devlop.siren.domain.item.dto.request;
 import com.devlop.siren.domain.category.dto.request.CategoryCreateRequest;
 import com.devlop.siren.domain.category.entity.Category;
 import com.devlop.siren.domain.item.entity.AllergyType;
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.entity.Item;
 import com.devlop.siren.domain.item.entity.Nutrition;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/devlop/siren/domain/item/dto/response/DefaultOptionResponse.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/response/DefaultOptionResponse.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.domain.item.dto.response;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/devlop/siren/domain/item/entity/Item.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/Item.java
@@ -2,6 +2,7 @@ package com.devlop.siren.domain.item.entity;
 
 import com.devlop.siren.domain.category.entity.Category;
 import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.utils.AllergyConverter;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/DefaultOption.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/DefaultOption.java
@@ -1,4 +1,4 @@
-package com.devlop.siren.domain.item.entity;
+package com.devlop.siren.domain.item.entity.option;
 
 import com.devlop.siren.domain.item.dto.request.DefaultOptionCreateRequest;
 import lombok.*;

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
@@ -15,11 +15,11 @@ public class OptionDetails {
     @NoArgsConstructor
     public class SyrupDetail {
         @Enumerated(EnumType.STRING)
-        private SyrupType type;
+        private SyrupType syrupType;
 
         private Integer cnt;
         public SyrupDetail(SyrupType type, int cnt){
-            this.type = type;
+            this.syrupType = type;
             this.cnt = cnt;
         }
     }
@@ -28,12 +28,12 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class DrizzleDetail {
         @Enumerated(EnumType.STRING)
-        private DrizzleType type;
+        private DrizzleType drizzleType;
 
         private Integer cnt;
 
         public DrizzleDetail(DrizzleType type, int cnt){
-            this.type = type;
+            this.drizzleType = type;
             this.cnt = cnt;
         }
     }
@@ -42,12 +42,12 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class EspressoDetail{
         @Enumerated(EnumType.STRING)
-        private EspressoType type;
+        private EspressoType espressoType;
 
         private Integer cnt;
 
         public EspressoDetail(EspressoType type, int cnt){
-            this.type = type;
+            this.espressoType = type;
             this.cnt = cnt;
         }
     }
@@ -56,14 +56,14 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class MilkDetail{
         @Enumerated(EnumType.STRING)
-        private MilkType type;
+        private MilkType milkType;
 
         @Enumerated(EnumType.STRING)
-        private Amount amount;
+        private Amount milkAmount;
 
         public MilkDetail(MilkType type, Amount amount){
-            this.type = type;
-            this.amount = amount;
+            this.milkType = type;
+            this.milkAmount = amount;
         }
     }
     @Embeddable
@@ -71,14 +71,14 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class FoamDetail{
         @Enumerated(EnumType.STRING)
-        private FoamType type;
+        private FoamType foamType;
 
         @Enumerated(EnumType.STRING)
-        private Amount amount;
+        private Amount foamAmount;
 
         public FoamDetail(FoamType type, Amount amount){
-            this.type = type;
-            this.amount = amount;
+            this.foamType = type;
+            this.foamAmount = amount;
         }
     }
 
@@ -87,11 +87,11 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class PotionDetail{
         @Enumerated(EnumType.STRING)
-        private PotionType type;
+        private PotionType potionType;
         private Integer cnt;
 
         public PotionDetail(PotionType type, int cnt){
-            this.type = type;
+            this.potionType = type;
             this.cnt = cnt;
         }
     }

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
@@ -1,0 +1,109 @@
+package com.devlop.siren.domain.item.entity.option;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
+public class OptionDetails {
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class SyrupDetail {
+        @Enumerated(EnumType.STRING)
+        private SyrupType type;
+
+        private Integer cnt;
+        public SyrupDetail(SyrupType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class DrizzleDetail {
+        @Enumerated(EnumType.STRING)
+        private DrizzleType type;
+
+        private Integer cnt;
+
+        public DrizzleDetail(DrizzleType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class EspressoDetail{
+        @Enumerated(EnumType.STRING)
+        private EspressoType type;
+
+        private Integer cnt;
+
+        public EspressoDetail(EspressoType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class MilkDetail{
+        @Enumerated(EnumType.STRING)
+        private MilkType type;
+
+        @Enumerated(EnumType.STRING)
+        private Amount amount;
+
+        public MilkDetail(MilkType type, Amount amount){
+            this.type = type;
+            this.amount = amount;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class FoamDetail{
+        @Enumerated(EnumType.STRING)
+        private FoamType type;
+
+        @Enumerated(EnumType.STRING)
+        private Amount amount;
+
+        public FoamDetail(FoamType type, Amount amount){
+            this.type = type;
+            this.amount = amount;
+        }
+    }
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class PotionDetail{
+        @Enumerated(EnumType.STRING)
+        private PotionType type;
+        private Integer cnt;
+
+        public PotionDetail(PotionType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Getter
+    @NoArgsConstructor
+    public enum PotionType{
+        BUTTER(500),
+        CREAM_CHEESE(1000);
+
+        private Integer price;
+        PotionType(Integer price) {
+            this.price = price;
+        }
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionTypeGroup.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionTypeGroup.java
@@ -1,0 +1,26 @@
+package com.devlop.siren.domain.item.entity.option;
+
+public class OptionTypeGroup {
+
+    public enum Temperature{
+        HOT, COLD, NONE
+    }
+    public enum Amount{
+        LITTLE, NORMAL, MUCH, NONE;
+    }
+    public enum EspressoType{
+        ORIGINAL, DECAFFEINE
+    }
+    public enum MilkType{
+        ORIGINAL, LOW_FAT, FAT_FREE, SOY, OAT
+    }
+    public enum FoamType{
+        MILK, ESPRESSO, MATCHA
+    }
+    public enum SyrupType{
+        VANILLA, CARAMEL, HAZELNUT, CLASSIC;
+    }
+    public enum DrizzleType{
+        CHOCOLATE, CARAMEL;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/SizeType.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/SizeType.java
@@ -1,4 +1,4 @@
-package com.devlop.siren.domain.item.entity;
+package com.devlop.siren.domain.item.entity.option;
 
 import com.devlop.siren.global.common.response.ResponseCode;
 import com.devlop.siren.global.exception.GlobalException;

--- a/src/main/java/com/devlop/siren/domain/item/repository/DefaultOptionRepository.java
+++ b/src/main/java/com/devlop/siren/domain/item/repository/DefaultOptionRepository.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.domain.item.repository;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DefaultOptionRepository extends JpaRepository<DefaultOption, Long> {

--- a/src/main/java/com/devlop/siren/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/devlop/siren/domain/item/service/ItemServiceImpl.java
@@ -11,7 +11,7 @@ import com.devlop.siren.domain.item.dto.response.ItemDetailResponse;
 import com.devlop.siren.domain.item.dto.response.ItemResponse;
 import com.devlop.siren.domain.item.dto.response.NutritionDetailResponse;
 import com.devlop.siren.domain.item.entity.AllergyType;
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.entity.Item;
 import com.devlop.siren.domain.item.entity.Nutrition;
 import com.devlop.siren.domain.item.repository.DefaultOptionRepository;

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -34,7 +34,7 @@ public class Order extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OrderState status;
 
-    private Integer totalPrice = 0;
+    private Integer totalAmount = 0;
 
     public static Order of(User user, Store store, List<OrderItem> items){
         Order newOrder = new Order();
@@ -42,13 +42,13 @@ public class Order extends BaseEntity {
         newOrder.setStore(store);
         newOrder.setStatus(OrderState.INIT);
         newOrder.setOrderItem(items);
-        newOrder.setTotalPrice(getTotalPrice(items));
+        newOrder.setTotalAmount(getTotalAmount(items));
         return newOrder;
     }
-    private static int getTotalPrice(List<OrderItem> items){
+    private static int getTotalAmount(List<OrderItem> items){
         return items.stream()
                 .mapToInt(item -> item.getItem().getPrice() * item.getQuantity()
-                        + item.getCustomOption().getPrice())
+                        + item.getCustomOption().getAdditionalAmount())
                 .sum();
     }
     public void cancel(){
@@ -62,8 +62,8 @@ public class Order extends BaseEntity {
         this.store = store;
         store.getOrders().add(this);
     }
-    private void setTotalPrice(Integer totalPrice) {
-        this.totalPrice = totalPrice;
+    private void setTotalAmount(Integer amount) {
+        this.totalAmount = amount;
     }
     private void setOrderItem(List<OrderItem> items){
         items.stream()

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -1,0 +1,79 @@
+package com.devlop.siren.domain.order.domain;
+
+import com.devlop.siren.domain.store.domain.Store;
+import com.devlop.siren.domain.user.domain.User;
+import com.devlop.siren.global.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<OrderItem>();
+
+    @Enumerated(EnumType.STRING)
+    private OrderState status;
+
+    private Integer totalPrice = 0;
+
+    public static Order of(User user, Store store, List<OrderItem> items){
+        Order newOrder = new Order();
+        newOrder.setUser(user);
+        newOrder.setStore(store);
+        newOrder.setStatus(OrderState.INIT);
+        newOrder.setOrderItem(items);
+        newOrder.setTotalPrice(getTotalPrice(items));
+        return newOrder;
+    }
+    private static int getTotalPrice(List<OrderItem> items){
+        return items.stream()
+                .mapToInt(item -> item.getItem().getPrice() * item.getQuantity()
+                        + item.getCustomOption().getPrice())
+                .sum();
+    }
+    public void cancel(){
+        status = OrderState.CANCELLED;
+    }
+    private void setUser(User user){
+        this.user = user;
+        user.getOrders().add(this);
+    }
+    private void setStore(Store store) {
+        this.store = store;
+        store.getOrders().add(this);
+    }
+    private void setTotalPrice(Integer totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+    private void setOrderItem(List<OrderItem> items){
+        items.stream()
+                .map(orderItem -> {
+                    orderItems.add(orderItem);
+                    orderItem.setOrder(this);
+                    return orderItem;
+                });
+    }
+    private void setStatus(OrderState status){
+        this.status = status;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/OrderItem.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/OrderItem.java
@@ -1,0 +1,56 @@
+package com.devlop.siren.domain.order.domain;
+
+import com.devlop.siren.domain.item.entity.Item;
+import com.devlop.siren.domain.order.domain.option.CustomOption;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_items", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"order_id", "item_id"})
+})
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_option_id")
+    private CustomOption customOption;
+
+    private Integer quantity;
+
+    public static OrderItem create(Item item, CustomOption customOption, Integer quantity){
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setCustomOption(customOption);
+        orderItem.setQuantity(quantity);
+        //TODO :: item.deduct(quantity)
+        return orderItem;
+    }
+    public void setOrder(Order order){
+        this.order = order;
+    }
+    private void setItem(Item item){
+        this.item = item;
+    }
+    private void setCustomOption(CustomOption option){
+        this.customOption = option;
+    }
+    private void setQuantity(Integer quantity){
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/OrderState.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/OrderState.java
@@ -1,0 +1,10 @@
+package com.devlop.siren.domain.order.domain;
+
+public enum OrderState {
+    INIT,      // 주문 생성
+    READY,      // 제조 대기
+    PREPARING,  // 제조 중
+    PICKUP,     // 픽업 대기
+    COMPLETED,   // 픽업 완료
+    CANCELLED,  // 주문 취소
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -1,0 +1,115 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import com.devlop.siren.domain.item.entity.SizeType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@DiscriminatorValue("Beverage")
+@Table(name = "beverage_options")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BeverageOption extends CustomOption {
+    @Column(name = "cup_size", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SizeType cupSize = SizeType.TALL;
+    @Column(name = "espresso_type")
+    @Enumerated(EnumType.STRING)
+    private EspressoType espressoType = EspressoType.ORIGINAL;
+    @Column(name = "espresso_shot_cnt")
+    private Integer espressoShotCnt;
+    @Column(name = "milk_type")
+    @Enumerated(EnumType.STRING)
+    private MilkType milkType = MilkType.ORIGINAL;
+    @Column(name = "whipped_cream_amount")
+    @Enumerated(EnumType.STRING)
+    private WhippedCreamAmount whippedCreamAmount;
+
+    @ElementCollection
+    @CollectionTable(name = "syrup_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "syrup_type")
+    private Set<SyrupDetail> syrupTypes = new HashSet<SyrupDetail>();
+
+    @ElementCollection
+    @CollectionTable(name = "drizzle_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "drizzle_type")
+    private Set<DrizzleDetail> drizzleTypes = new HashSet<DrizzleDetail>();
+
+    @Override
+    public int getPrice() {
+        int additionalPrice = 0;
+
+        if(!this.cupSize.equals(SizeType.TALL)){
+            additionalPrice += PriceType.SIZE_UP.getPrice() * cupSize.ordinal();
+        }
+        if(this.milkType.equals(MilkType.OAT))
+            additionalPrice += PriceType.CHANGE_OAT_MILK.getPrice();
+
+        if(!this.espressoType.equals(EspressoType.ORIGINAL))
+            additionalPrice += PriceType.ADD_ESPRESSO_SHOT.getPrice() * this.espressoShotCnt;
+
+        if(this.whippedCreamAmount != null)
+            additionalPrice += PriceType.ADD_WHIPPED_CREAM.getPrice();
+
+        if(this.syrupTypes.size() > 0){
+            additionalPrice += syrupTypes.stream()
+                    .map(syrup -> PriceType.ADD_SYRUP.getPrice() * syrup.getCnt())
+                    .mapToInt(Integer::intValue)
+                    .sum();
+        }
+        if(this.drizzleTypes.size() > 0){
+            additionalPrice += drizzleTypes.stream()
+                    .map(drizzle -> PriceType.ADD_DRIZZLE.getPrice() * drizzle.getCnt())
+                    .mapToInt(Integer::intValue)
+                    .sum();
+        }
+        return additionalPrice;
+    }
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class SyrupDetail {
+        @Enumerated(EnumType.STRING)
+        private SyrupType type;
+        private int cnt;
+        public SyrupDetail(SyrupType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class DrizzleDetail {
+        @Enumerated(EnumType.STRING)
+        DrizzleType type;
+        int cnt;
+        public DrizzleDetail(DrizzleType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    enum EspressoType{
+        ORIGINAL, DECAFFEINE, BLOND, HALF_DECAFFEINE
+    }
+    enum MilkType{
+        ORIGINAL, LOW_FAT, FAT_FREE, SOY, OAT
+    }
+    enum WhippedCreamAmount{
+        LITTLE, MUCH, NORMAL, NONE;
+    }
+    enum SyrupType{
+        VANILLA, CARAMEL, HAZELNUT, CLASSIC;
+    }
+    enum DrizzleType{
+        CHOCOLATE, CARAMEL;
+    }
+}
+

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -48,9 +48,10 @@ public class BeverageOption extends CustomOption {
     private Set<DrizzleDetail> drizzle = new HashSet<DrizzleDetail>();
 
     @Builder
-    public BeverageOption(Boolean takeout, SizeType cupSize, EspressoDetail espresso, MilkDetail milk,
+    public BeverageOption(Boolean takeout, Temperature temperature, SizeType cupSize, EspressoDetail espresso, MilkDetail milk,
                           FoamDetail foam, Set<SyrupDetail> syrup, Set<DrizzleDetail> drizzle) {
         this.takeout = takeout;
+        this.temperature = temperature;
         this.cupSize = cupSize;
         this.espresso = espresso;
         this.milk = milk;

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -68,7 +68,7 @@ public class BeverageOption extends CustomOption {
         if(espresso != null)
             amount += PriceType.ADD_ESPRESSO_SHOT.getPrice() * espresso.getCnt();
 
-        if(milk != null && milk.getType().equals(MilkType.OAT))
+        if(milk != null && milk.getMilkType().equals(MilkType.OAT))
             amount += PriceType.CHANGE_OAT_MILK.getPrice();
 
         if(foam != null)

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -6,10 +6,11 @@ import javax.persistence.*;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name = "TYPE")
+@DiscriminatorColumn
 public abstract class CustomOption {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "custom_option_id")
     private Long id;
 
     @Column(name = "take_out", nullable = false)
@@ -20,7 +21,7 @@ public abstract class CustomOption {
     protected Temperature temperature;
 
     @Column(name = "additional_amount")
-    protected Integer amount = 0;
+    protected int amount = 0;
 
     public abstract int getAdditionalAmount();
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -1,5 +1,7 @@
 package com.devlop.siren.domain.order.domain.option;
 
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
 import javax.persistence.*;
 
 @Entity
@@ -9,22 +11,18 @@ public abstract class CustomOption {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(name = "take_out", nullable = false)
-    private Boolean takeout;
-    @Column(name = "cold", nullable = false)
+    protected Boolean takeout;
+
+    @Column(name = "temperature", nullable = false)
     @Enumerated(EnumType.STRING)
-    private Temperature temperature;
-    @Column(name = "additional_price")
-    private int price = 0;
+    protected Temperature temperature;
 
-    public abstract int getPrice();
-    public void setTemperature(Temperature temperature) {
-        this.temperature = temperature;
-    }
+    @Column(name = "additional_amount")
+    protected Integer amount = 0;
 
-    enum Temperature{
-        HOT, COLD
-    }
+    public abstract int getAdditionalAmount();
 }
 
 

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -1,0 +1,30 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import javax.persistence.*;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "TYPE")
+public abstract class CustomOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "take_out", nullable = false)
+    private Boolean takeout;
+    @Column(name = "cold", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Temperature temperature;
+    @Column(name = "additional_price")
+    private int price = 0;
+
+    public abstract int getPrice();
+    public void setTemperature(Temperature temperature) {
+        this.temperature = temperature;
+    }
+
+    enum Temperature{
+        HOT, COLD
+    }
+}
+
+

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -51,7 +51,7 @@ public class FoodOption extends CustomOption{
     public int getAdditionalAmount() {
         if(potion.size() > 0){
             amount += potion.stream()
-                    .mapToInt(potion -> potion.getType().getPrice() * potion.getCnt())
+                    .mapToInt(potion -> potion.getPotionType().getPrice() * potion.getCnt())
                     .sum();
         }
         return amount;

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -1,0 +1,18 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@DiscriminatorValue("Food")
+@Table(name = "food_options")
+public class FoodOption extends CustomOption{
+    protected FoodOption() {
+        this.setTemperature(CustomOption.Temperature.COLD);
+    }
+    @Override
+    public int getPrice() {
+        return 0;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -1,18 +1,61 @@
 package com.devlop.siren.domain.order.domain.option;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import com.devlop.siren.domain.item.entity.Item;
+import com.devlop.siren.domain.item.entity.option.OptionDetails.*;
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @DiscriminatorValue("Food")
+@NoArgsConstructor
 @Table(name = "food_options")
 public class FoodOption extends CustomOption{
-    protected FoodOption() {
-        this.setTemperature(CustomOption.Temperature.COLD);
+    /*
+    * 추가 옵션 없는 카테고리: 케이크, 샐러드, 아이스크림, 과일, 요거트, 스낵
+    * 포션 옵션 추가되는 카테고리: 브레드
+    * 데움 옵션 추가되는 카테고리: 샌드위치, 브레드, 수프
+    * */
+    @ElementCollection
+    @CollectionTable(name = "potion_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "potion_type")
+    private Set<PotionDetail> potion = new HashSet<PotionDetail>();
+
+    static Set<String> categoriesWithoutOptions = Set.of("Cake", "Salad", "IceCream", "Fruit", "Yogurt", "Snack");
+    static Set<String> categoriesWithPotionOption = Set.of("Bread");
+    static Set<String> categoriesRequiringWarming = Set.of("Sandwich", "Bread", "Soup");
+
+    @Builder
+    public FoodOption(Item item, Boolean isWarmed, Boolean isTakeOut, Set<PotionDetail> potions) {
+        takeout = isTakeOut;
+
+        String categoryName = item.getCategory().getCategoryName();
+        if(categoriesRequiringWarming.contains(categoryName))
+            temperature = isWarmed ? Temperature.HOT : Temperature.NONE;
+
+        if(categoriesWithoutOptions.contains(categoryName)){
+            temperature = Temperature.NONE;
+        }
+
+        if(categoriesWithPotionOption.contains(categoryName)){
+            potion = potions;
+        }
     }
     @Override
-    public int getPrice() {
-        return 0;
+    public int getAdditionalAmount() {
+        if(potion.size() > 0){
+            amount += potion.stream()
+                    .mapToInt(potion -> potion.getType().getPrice() * potion.getCnt())
+                    .sum();
+        }
+        return amount;
     }
+
+
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
@@ -10,13 +10,13 @@ public enum PriceType {
     ADD_ESPRESSO_SHOT(600),
     ADD_SYRUP(600),
     ADD_DRIZZLE(600),
-    ADD_WHIPPED_CREAM(600)
+    ADD_FOAM(600)
     ;
 
     private int price;
 
-    PriceType(int additionalPrice){
-        this.price = additionalPrice;
+    PriceType(int price){
+        this.price = price;
     }
 
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
@@ -1,0 +1,22 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import lombok.Getter;
+
+@Getter
+public enum PriceType {
+    SIZE_UP(500),
+    CHANGE_OAT_MILK(600),
+
+    ADD_ESPRESSO_SHOT(600),
+    ADD_SYRUP(600),
+    ADD_DRIZZLE(600),
+    ADD_WHIPPED_CREAM(600)
+    ;
+
+    private int price;
+
+    PriceType(int additionalPrice){
+        this.price = additionalPrice;
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/store/domain/Store.java
+++ b/src/main/java/com/devlop/siren/domain/store/domain/Store.java
@@ -1,10 +1,13 @@
 package com.devlop.siren.domain.store.domain;
 
+import com.devlop.siren.domain.order.domain.Order;
 import com.devlop.siren.domain.store.dto.request.StoreUpdateRequest;
 import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -35,6 +38,8 @@ public class Store {
     private Double latitude;
     @Column(name = "longitude", columnDefinition = "NVARCHAR(255) NOT NULL" )
     private Double longitude;
+    @OneToMany(mappedBy = "store")
+    private List<Order> orders = new ArrayList<Order>();
 
     @Builder
     public Store(Long storeId, String storeName, String storePhone, String city, String street,

--- a/src/main/java/com/devlop/siren/domain/user/domain/User.java
+++ b/src/main/java/com/devlop/siren/domain/user/domain/User.java
@@ -2,6 +2,7 @@ package com.devlop.siren.domain.user.domain;
 //
 import com.devlop.siren.domain.item.entity.AllergyType;
 import com.devlop.siren.domain.item.utils.AllergyConverter;
+import com.devlop.siren.domain.order.domain.Order;
 import com.devlop.siren.domain.user.utils.KoreanNickname;
 import com.devlop.siren.global.common.BaseEntity;
 import lombok.AccessLevel;
@@ -14,7 +15,9 @@ import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -48,6 +51,9 @@ public class User extends BaseEntity {
     @Column(name = "allergy")
     @Convert(converter = AllergyConverter.class)
     private EnumSet<AllergyType> allergies;
+
+    @OneToMany(mappedBy = "user")
+    private List<Order> orders = new ArrayList<Order>();
 
     @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
     private boolean isDeleted;

--- a/src/main/java/com/devlop/siren/domain/user/domain/User.java
+++ b/src/main/java/com/devlop/siren/domain/user/domain/User.java
@@ -29,6 +29,7 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Column(unique = true)

--- a/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
@@ -6,7 +6,7 @@ import com.devlop.siren.domain.item.controller.ItemController;
 import com.devlop.siren.domain.item.dto.request.DefaultOptionCreateRequest;
 import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
 import com.devlop.siren.domain.item.dto.request.NutritionCreateRequest;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import com.devlop.siren.domain.item.service.ItemService;
 import com.devlop.siren.domain.user.dto.UserDetailsDto;
 import com.devlop.siren.global.util.UserInformation;

--- a/src/test/java/com/devlop/siren/item/service/ItemServiceImplTest.java
+++ b/src/test/java/com/devlop/siren/item/service/ItemServiceImplTest.java
@@ -9,7 +9,7 @@ import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
 import com.devlop.siren.domain.item.dto.request.NutritionCreateRequest;
 import com.devlop.siren.domain.item.entity.AllergyType;
 import com.devlop.siren.domain.item.entity.Item;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import com.devlop.siren.domain.item.repository.DefaultOptionRepository;
 import com.devlop.siren.domain.item.repository.ItemRepository;
 import com.devlop.siren.domain.item.repository.NutritionRepository;


### PR DESCRIPTION
## 🎯 What is this PR
> 주문API 개발 전 관련 엔티티 정의 

## 📄 Changes Made
- 주문 엔티티, 주문아이템 엔티티, 주문아이템 생성시 필요한 CustomOption 엔티티 구현
- 유저와 스토어 엔티티에 List<Order> 추가

## 📸 Screenshot
> 생성되는 db 테이블 구조 확인 
<img width="616" alt="image" src="https://github.com/Siren-repo/Siren/assets/35358294/f9a67ac6-f1fe-49e0-ae3a-d8b6c745f8bf">
<img width="553" alt="image" src="https://github.com/Siren-repo/Siren/assets/35358294/a4636448-6f37-4efd-b6fd-2950243393f0">
<img width="659" alt="image" src="https://github.com/Siren-repo/Siren/assets/35358294/bccd8f37-8aac-4ed4-961e-467b67611418">

## 🙋🏻‍ Review Point
- Order, OrderItem에 정의된 연관관계가 올바른지
- CustomOption을 Food와 Beverage로 구분하기 위해 사용한 상속매핑에 대한 피드백 
- 하나의 커스텀 옵션에 Syrup과 Drizzle을 여러개 추가 할 수 있기 때문에 값타입 클래스 생성하고, Set 컬렉션에 넣었는데 이렇게 컬렉션을 사용함으로써 CollectionTable이 생겨난 현재 방식에 대한 피드백
- User, Store엔티티에 추가된 OneToMany관계의 List<Order> 생성에 대한 피드백

## Question 
저번에 주문 완료 시 재고감소, 주문취소 시 재고증가를 위해 OrderItem, Order에서 Stock 접근이 필요하다고 말씀드렸는데, 제가 기억하기로는 OrderService에서 StockRepository를 주입받아 Stock을 조회해오고 Stock.reduce()등의 엔티티 static 메소드를 호출하여 처리하는걸로 의견이 나왔던거 같은데 맞을까요? 
OrderService의 createOrder() 자체가 User, Store, Item을 찾아와서 OrderItem, CustomOption, Payment 등을 만드는 역할인데 지금도 책임이 많이 부여되어있는 것 같아 주문생성과 깊은 관계가 아니면 관심사를 분리하고 싶습니다. OrderService에서 StockService에 있는 재고감소 로직(ex. reduceStock(Item item, int quantity))을 호출해서 서비스 레이어 사이에서만 접근하도록 하는건 어떨까요? 해당 방법이 좀 해결이 될 수 있는건지 아니면 다른 좋은 방법이 있는지 궁금합니다.

## 🔗 Reference
Issue #23