### PR TITLE
feat : Payments 엔티티 구현 (#28)

### DIFF
--- a/src/main/java/com/devlop/siren/domain/payment/domain/Payment.java
+++ b/src/main/java/com/devlop/siren/domain/payment/domain/Payment.java
@@ -1,0 +1,73 @@
+package com.devlop.siren.domain.payment.domain;
+
+import com.devlop.siren.domain.payment.dto.response.PaymentResponse;
+import com.devlop.siren.domain.store.domain.Store;
+import com.devlop.siren.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+/*
+ * 성공 orderId, paymentKey, amount 3개를 리턴 받아야 함.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentId; // 결제 id
+    @Column(name = "amount")
+    private Long amount; // 결제 금액
+    @Column(name="order_name")
+    private String orderName; // 주문상품
+    @Column(name = "order_id")
+    private String orderId; // 상품 ID (랜덤 String )
+
+    @Column(name = "payment_type")
+    @Enumerated(EnumType.STRING)
+    private PaymentType paymentType; // 현금  or 카드
+
+
+    @Column(name = "payment_key")
+    private String paymentKey; // 결제 승인시 발급 해주는 키
+
+    @Column(name ="payment_status", columnDefinition = "TINYINT(1)")
+    private Boolean paymentStatus; // 결제 승인 성공 여부
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Builder
+    public Payment(Long paymentId, Long amount, String orderName,Boolean paymentStatus,
+                   String orderId, PaymentType paymentType, String paymentKey,
+                   User user, Store store) {
+        this.paymentId = paymentId;
+        this.amount = amount;
+        this.orderName = orderName;
+        this.orderId = orderId;
+        this.paymentStatus = paymentStatus;
+        this.paymentType = paymentType;
+        this.paymentKey = paymentKey;
+        this.user = user;
+        this.store = store;
+    }
+
+    public PaymentResponse toEntity(){
+        return PaymentResponse.builder()
+                .paymentType(paymentType.getPaymentName())
+                .amount(amount)
+                .orderName(orderName)
+                .orderId(orderId)
+                .userNickName(user.getNickName())
+                .build();
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/payment/domain/PaymentType.java
+++ b/src/main/java/com/devlop/siren/domain/payment/domain/PaymentType.java
@@ -1,0 +1,15 @@
+package com.devlop.siren.domain.payment.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentType {
+    CARD("카드"),
+    CASH("현금");
+
+    private final String paymentName;
+
+    PaymentType(String paymentName) {
+        this.paymentName = paymentName;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/payment/dto/request/PaymentRequest.java
+++ b/src/main/java/com/devlop/siren/domain/payment/dto/request/PaymentRequest.java
@@ -1,0 +1,36 @@
+package com.devlop.siren.domain.payment.dto.request;
+
+import com.devlop.siren.domain.payment.domain.Payment;
+import com.devlop.siren.domain.payment.domain.PaymentType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentRequest {
+    @NotNull
+    private PaymentType paymentType; // 카드 , 현금
+    @NotNull
+    private Long amount; // 금액
+    @NotNull
+    private String orderName; // 주문상품
+
+    private String successUrl; // 성공시 url
+    private String failUrl; // 실패시 url
+
+    public Payment toEntity() {
+        return Payment.builder()
+                .paymentType(paymentType)
+                .amount(amount)
+                .orderName(orderName)
+                .orderId(UUID.randomUUID().toString())
+                .paymentStatus(false)
+                .build();
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/devlop/siren/domain/payment/dto/response/PaymentResponse.java
@@ -1,0 +1,28 @@
+package com.devlop.siren.domain.payment.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentResponse {
+
+    private String paymentType;
+    private Long amount;
+    private String orderName;
+    private String orderId;
+    private String successUrl;
+    private String failUrl;
+    private String userNickName;
+
+    @Builder
+    public PaymentResponse(String paymentType, Long amount, String orderName,
+                           String orderId, String successUrl, String failUrl, String userNickName) {
+        this.paymentType = paymentType;
+        this.amount = amount;
+        this.orderName = orderName;
+        this.orderId = orderId;
+        this.successUrl = successUrl;
+        this.failUrl = failUrl;
+        this.userNickName = userNickName;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,12 @@ google:
   geocoding:
     key:
       ${GeocodingService_KEY}
+toss:
+  payment:
+    client-key: ${TOSS_CLIENT_KEY}
+    secret-key: ${TOSS_SECRET_KEY}
+    success-url: "http://localhost:8080/api/toss/payments/success"
+    fail-url: "http://localhost:8080/api/toss/payments/fail"
 
 server:
   servlet:


### PR DESCRIPTION
## 🎯 What is this PR
> 결제 시스템 API 구현 전 결제 승인 엔티티 구현

## 📄 Changes Made
- tossPayment 필수 Entity 구현
- payment 결제승인 (Request / Response) 구현
- paymentType (현금 / 카드) Enum객체 구현


## 📸 Screenshot
> 스크린 샷 첨부
![image](https://github.com/Siren-repo/Siren/assets/80689135/5aa91f3e-f52d-4f47-9045-128ff934f3a3)

## 🙋🏻‍ Review Point
-  현재 구현한 코드에서는 payment 와 다대일 관계 User  / 1:1 관계 Store로 구현했을 때 생기는 문제점이 있는지
- ErdCloud에 업데이트 해놨습니다.

## 🔗 Reference
Issue #{28}