### PR TITLE
feat: 유저 롤 변경 기능 추가

### DIFF
--- a/src/main/java/com/devlop/siren/domain/item/dto/request/DefaultOptionCreateRequest.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/request/DefaultOptionCreateRequest.java
@@ -1,7 +1,7 @@
 package com.devlop.siren.domain.item.dto.request;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/devlop/siren/domain/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/request/ItemCreateRequest.java
@@ -4,7 +4,7 @@ package com.devlop.siren.domain.item.dto.request;
 import com.devlop.siren.domain.category.dto.request.CategoryCreateRequest;
 import com.devlop.siren.domain.category.entity.Category;
 import com.devlop.siren.domain.item.entity.AllergyType;
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.entity.Item;
 import com.devlop.siren.domain.item.entity.Nutrition;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/devlop/siren/domain/item/dto/response/DefaultOptionResponse.java
+++ b/src/main/java/com/devlop/siren/domain/item/dto/response/DefaultOptionResponse.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.domain.item.dto.response;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/devlop/siren/domain/item/entity/Item.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/Item.java
@@ -2,6 +2,7 @@ package com.devlop.siren.domain.item.entity;
 
 import com.devlop.siren.domain.category.entity.Category;
 import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.utils.AllergyConverter;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/DefaultOption.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/DefaultOption.java
@@ -1,4 +1,4 @@
-package com.devlop.siren.domain.item.entity;
+package com.devlop.siren.domain.item.entity.option;
 
 import com.devlop.siren.domain.item.dto.request.DefaultOptionCreateRequest;
 import lombok.*;

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
@@ -15,11 +15,11 @@ public class OptionDetails {
     @NoArgsConstructor
     public class SyrupDetail {
         @Enumerated(EnumType.STRING)
-        private SyrupType type;
+        private SyrupType syrupType;
 
         private Integer cnt;
         public SyrupDetail(SyrupType type, int cnt){
-            this.type = type;
+            this.syrupType = type;
             this.cnt = cnt;
         }
     }
@@ -28,12 +28,12 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class DrizzleDetail {
         @Enumerated(EnumType.STRING)
-        private DrizzleType type;
+        private DrizzleType drizzleType;
 
         private Integer cnt;
 
         public DrizzleDetail(DrizzleType type, int cnt){
-            this.type = type;
+            this.drizzleType = type;
             this.cnt = cnt;
         }
     }
@@ -42,12 +42,12 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class EspressoDetail{
         @Enumerated(EnumType.STRING)
-        private EspressoType type;
+        private EspressoType espressoType;
 
         private Integer cnt;
 
         public EspressoDetail(EspressoType type, int cnt){
-            this.type = type;
+            this.espressoType = type;
             this.cnt = cnt;
         }
     }
@@ -56,14 +56,14 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class MilkDetail{
         @Enumerated(EnumType.STRING)
-        private MilkType type;
+        private MilkType milkType;
 
         @Enumerated(EnumType.STRING)
-        private Amount amount;
+        private Amount milkAmount;
 
         public MilkDetail(MilkType type, Amount amount){
-            this.type = type;
-            this.amount = amount;
+            this.milkType = type;
+            this.milkAmount = amount;
         }
     }
     @Embeddable
@@ -71,14 +71,14 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class FoamDetail{
         @Enumerated(EnumType.STRING)
-        private FoamType type;
+        private FoamType foamType;
 
         @Enumerated(EnumType.STRING)
-        private Amount amount;
+        private Amount foamAmount;
 
         public FoamDetail(FoamType type, Amount amount){
-            this.type = type;
-            this.amount = amount;
+            this.foamType = type;
+            this.foamAmount = amount;
         }
     }
 
@@ -87,11 +87,11 @@ public class OptionDetails {
     @NoArgsConstructor
     public static class PotionDetail{
         @Enumerated(EnumType.STRING)
-        private PotionType type;
+        private PotionType potionType;
         private Integer cnt;
 
         public PotionDetail(PotionType type, int cnt){
-            this.type = type;
+            this.potionType = type;
             this.cnt = cnt;
         }
     }

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionDetails.java
@@ -1,0 +1,109 @@
+package com.devlop.siren.domain.item.entity.option;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
+public class OptionDetails {
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class SyrupDetail {
+        @Enumerated(EnumType.STRING)
+        private SyrupType type;
+
+        private Integer cnt;
+        public SyrupDetail(SyrupType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class DrizzleDetail {
+        @Enumerated(EnumType.STRING)
+        private DrizzleType type;
+
+        private Integer cnt;
+
+        public DrizzleDetail(DrizzleType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class EspressoDetail{
+        @Enumerated(EnumType.STRING)
+        private EspressoType type;
+
+        private Integer cnt;
+
+        public EspressoDetail(EspressoType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class MilkDetail{
+        @Enumerated(EnumType.STRING)
+        private MilkType type;
+
+        @Enumerated(EnumType.STRING)
+        private Amount amount;
+
+        public MilkDetail(MilkType type, Amount amount){
+            this.type = type;
+            this.amount = amount;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class FoamDetail{
+        @Enumerated(EnumType.STRING)
+        private FoamType type;
+
+        @Enumerated(EnumType.STRING)
+        private Amount amount;
+
+        public FoamDetail(FoamType type, Amount amount){
+            this.type = type;
+            this.amount = amount;
+        }
+    }
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class PotionDetail{
+        @Enumerated(EnumType.STRING)
+        private PotionType type;
+        private Integer cnt;
+
+        public PotionDetail(PotionType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Getter
+    @NoArgsConstructor
+    public enum PotionType{
+        BUTTER(500),
+        CREAM_CHEESE(1000);
+
+        private Integer price;
+        PotionType(Integer price) {
+            this.price = price;
+        }
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/OptionTypeGroup.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/OptionTypeGroup.java
@@ -1,0 +1,26 @@
+package com.devlop.siren.domain.item.entity.option;
+
+public class OptionTypeGroup {
+
+    public enum Temperature{
+        HOT, COLD, NONE
+    }
+    public enum Amount{
+        LITTLE, NORMAL, MUCH, NONE;
+    }
+    public enum EspressoType{
+        ORIGINAL, DECAFFEINE
+    }
+    public enum MilkType{
+        ORIGINAL, LOW_FAT, FAT_FREE, SOY, OAT
+    }
+    public enum FoamType{
+        MILK, ESPRESSO, MATCHA
+    }
+    public enum SyrupType{
+        VANILLA, CARAMEL, HAZELNUT, CLASSIC;
+    }
+    public enum DrizzleType{
+        CHOCOLATE, CARAMEL;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/item/entity/option/SizeType.java
+++ b/src/main/java/com/devlop/siren/domain/item/entity/option/SizeType.java
@@ -1,4 +1,4 @@
-package com.devlop.siren.domain.item.entity;
+package com.devlop.siren.domain.item.entity.option;
 
 import com.devlop.siren.global.common.response.ResponseCode;
 import com.devlop.siren.global.exception.GlobalException;

--- a/src/main/java/com/devlop/siren/domain/item/repository/DefaultOptionRepository.java
+++ b/src/main/java/com/devlop/siren/domain/item/repository/DefaultOptionRepository.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.domain.item.repository;
 
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DefaultOptionRepository extends JpaRepository<DefaultOption, Long> {

--- a/src/main/java/com/devlop/siren/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/devlop/siren/domain/item/service/ItemServiceImpl.java
@@ -11,7 +11,7 @@ import com.devlop.siren.domain.item.dto.response.ItemDetailResponse;
 import com.devlop.siren.domain.item.dto.response.ItemResponse;
 import com.devlop.siren.domain.item.dto.response.NutritionDetailResponse;
 import com.devlop.siren.domain.item.entity.AllergyType;
-import com.devlop.siren.domain.item.entity.DefaultOption;
+import com.devlop.siren.domain.item.entity.option.DefaultOption;
 import com.devlop.siren.domain.item.entity.Item;
 import com.devlop.siren.domain.item.entity.Nutrition;
 import com.devlop.siren.domain.item.repository.DefaultOptionRepository;

--- a/src/main/java/com/devlop/siren/domain/order/controller/OrderController.java
+++ b/src/main/java/com/devlop/siren/domain/order/controller/OrderController.java
@@ -1,0 +1,26 @@
+package com.devlop.siren.domain.order.controller;
+
+import com.devlop.siren.domain.order.dto.request.OrderCreateRequest;
+import com.devlop.siren.domain.order.dto.response.OrderCreateResponse;
+import com.devlop.siren.domain.order.service.OrderUseCase;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.global.common.response.ApiResponse;
+import com.devlop.siren.global.common.response.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderUseCase orderUseCase;
+
+    @PostMapping
+    public ApiResponse<OrderCreateResponse> create(@Valid @RequestBody OrderCreateRequest request,
+                                                   @AuthenticationPrincipal UserDetailsDto user){
+        return ApiResponse.ok(ResponseCode.Normal.CREATE, orderUseCase.create(request, user));
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -34,7 +34,7 @@ public class Order extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OrderState status;
 
-    private Integer totalPrice = 0;
+    private Integer totalAmount = 0;
 
     public static Order of(User user, Store store, List<OrderItem> items){
         Order newOrder = new Order();
@@ -42,13 +42,13 @@ public class Order extends BaseEntity {
         newOrder.setStore(store);
         newOrder.setStatus(OrderState.INIT);
         newOrder.setOrderItem(items);
-        newOrder.setTotalPrice(getTotalPrice(items));
+        newOrder.setTotalAmount(getTotalAmount(items));
         return newOrder;
     }
-    private static int getTotalPrice(List<OrderItem> items){
+    private static int getTotalAmount(List<OrderItem> items){
         return items.stream()
                 .mapToInt(item -> item.getItem().getPrice() * item.getQuantity()
-                        + item.getCustomOption().getPrice())
+                        + item.getCustomOption().getAdditionalAmount())
                 .sum();
     }
     public void cancel(){
@@ -62,8 +62,8 @@ public class Order extends BaseEntity {
         this.store = store;
         store.getOrders().add(this);
     }
-    private void setTotalPrice(Integer totalPrice) {
-        this.totalPrice = totalPrice;
+    private void setTotalAmount(Integer amount) {
+        this.totalAmount = amount;
     }
     private void setOrderItem(List<OrderItem> items){
         items.stream()

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/devlop/siren/domain/order/domain/Order.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/Order.java
@@ -1,0 +1,79 @@
+package com.devlop.siren.domain.order.domain;
+
+import com.devlop.siren.domain.store.domain.Store;
+import com.devlop.siren.domain.user.domain.User;
+import com.devlop.siren.global.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<OrderItem>();
+
+    @Enumerated(EnumType.STRING)
+    private OrderState status;
+
+    private Integer totalPrice = 0;
+
+    public static Order of(User user, Store store, List<OrderItem> items){
+        Order newOrder = new Order();
+        newOrder.setUser(user);
+        newOrder.setStore(store);
+        newOrder.setStatus(OrderState.INIT);
+        newOrder.setOrderItem(items);
+        newOrder.setTotalPrice(getTotalPrice(items));
+        return newOrder;
+    }
+    private static int getTotalPrice(List<OrderItem> items){
+        return items.stream()
+                .mapToInt(item -> item.getItem().getPrice() * item.getQuantity()
+                        + item.getCustomOption().getPrice())
+                .sum();
+    }
+    public void cancel(){
+        status = OrderState.CANCELLED;
+    }
+    private void setUser(User user){
+        this.user = user;
+        user.getOrders().add(this);
+    }
+    private void setStore(Store store) {
+        this.store = store;
+        store.getOrders().add(this);
+    }
+    private void setTotalPrice(Integer totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+    private void setOrderItem(List<OrderItem> items){
+        items.stream()
+                .map(orderItem -> {
+                    orderItems.add(orderItem);
+                    orderItem.setOrder(this);
+                    return orderItem;
+                });
+    }
+    private void setStatus(OrderState status){
+        this.status = status;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/OrderItem.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/OrderItem.java
@@ -1,0 +1,56 @@
+package com.devlop.siren.domain.order.domain;
+
+import com.devlop.siren.domain.item.entity.Item;
+import com.devlop.siren.domain.order.domain.option.CustomOption;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_items", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"order_id", "item_id"})
+})
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_option_id")
+    private CustomOption customOption;
+
+    private Integer quantity;
+
+    public static OrderItem create(Item item, CustomOption customOption, Integer quantity){
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setCustomOption(customOption);
+        orderItem.setQuantity(quantity);
+        //TODO :: item.deduct(quantity)
+        return orderItem;
+    }
+    public void setOrder(Order order){
+        this.order = order;
+    }
+    private void setItem(Item item){
+        this.item = item;
+    }
+    private void setCustomOption(CustomOption option){
+        this.customOption = option;
+    }
+    private void setQuantity(Integer quantity){
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/OrderState.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/OrderState.java
@@ -1,0 +1,10 @@
+package com.devlop.siren.domain.order.domain;
+
+public enum OrderState {
+    INIT,      // 주문 생성
+    READY,      // 제조 대기
+    PREPARING,  // 제조 중
+    PICKUP,     // 픽업 대기
+    COMPLETED,   // 픽업 완료
+    CANCELLED,  // 주문 취소
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/OrderStatus.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/OrderStatus.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.domain.order.domain;
 
-public enum OrderState {
+public enum OrderStatus {
     INIT,      // 주문 생성
     READY,      // 제조 대기
     PREPARING,  // 제조 중

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -1,0 +1,115 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import com.devlop.siren.domain.item.entity.SizeType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@DiscriminatorValue("Beverage")
+@Table(name = "beverage_options")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BeverageOption extends CustomOption {
+    @Column(name = "cup_size", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SizeType cupSize = SizeType.TALL;
+    @Column(name = "espresso_type")
+    @Enumerated(EnumType.STRING)
+    private EspressoType espressoType = EspressoType.ORIGINAL;
+    @Column(name = "espresso_shot_cnt")
+    private Integer espressoShotCnt;
+    @Column(name = "milk_type")
+    @Enumerated(EnumType.STRING)
+    private MilkType milkType = MilkType.ORIGINAL;
+    @Column(name = "whipped_cream_amount")
+    @Enumerated(EnumType.STRING)
+    private WhippedCreamAmount whippedCreamAmount;
+
+    @ElementCollection
+    @CollectionTable(name = "syrup_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "syrup_type")
+    private Set<SyrupDetail> syrupTypes = new HashSet<SyrupDetail>();
+
+    @ElementCollection
+    @CollectionTable(name = "drizzle_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "drizzle_type")
+    private Set<DrizzleDetail> drizzleTypes = new HashSet<DrizzleDetail>();
+
+    @Override
+    public int getPrice() {
+        int additionalPrice = 0;
+
+        if(!this.cupSize.equals(SizeType.TALL)){
+            additionalPrice += PriceType.SIZE_UP.getPrice() * cupSize.ordinal();
+        }
+        if(this.milkType.equals(MilkType.OAT))
+            additionalPrice += PriceType.CHANGE_OAT_MILK.getPrice();
+
+        if(!this.espressoType.equals(EspressoType.ORIGINAL))
+            additionalPrice += PriceType.ADD_ESPRESSO_SHOT.getPrice() * this.espressoShotCnt;
+
+        if(this.whippedCreamAmount != null)
+            additionalPrice += PriceType.ADD_WHIPPED_CREAM.getPrice();
+
+        if(this.syrupTypes.size() > 0){
+            additionalPrice += syrupTypes.stream()
+                    .map(syrup -> PriceType.ADD_SYRUP.getPrice() * syrup.getCnt())
+                    .mapToInt(Integer::intValue)
+                    .sum();
+        }
+        if(this.drizzleTypes.size() > 0){
+            additionalPrice += drizzleTypes.stream()
+                    .map(drizzle -> PriceType.ADD_DRIZZLE.getPrice() * drizzle.getCnt())
+                    .mapToInt(Integer::intValue)
+                    .sum();
+        }
+        return additionalPrice;
+    }
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class SyrupDetail {
+        @Enumerated(EnumType.STRING)
+        private SyrupType type;
+        private int cnt;
+        public SyrupDetail(SyrupType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public class DrizzleDetail {
+        @Enumerated(EnumType.STRING)
+        DrizzleType type;
+        int cnt;
+        public DrizzleDetail(DrizzleType type, int cnt){
+            this.type = type;
+            this.cnt = cnt;
+        }
+    }
+    enum EspressoType{
+        ORIGINAL, DECAFFEINE, BLOND, HALF_DECAFFEINE
+    }
+    enum MilkType{
+        ORIGINAL, LOW_FAT, FAT_FREE, SOY, OAT
+    }
+    enum WhippedCreamAmount{
+        LITTLE, MUCH, NORMAL, NONE;
+    }
+    enum SyrupType{
+        VANILLA, CARAMEL, HAZELNUT, CLASSIC;
+    }
+    enum DrizzleType{
+        CHOCOLATE, CARAMEL;
+    }
+}
+

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -48,9 +48,10 @@ public class BeverageOption extends CustomOption {
     private Set<DrizzleDetail> drizzle = new HashSet<DrizzleDetail>();
 
     @Builder
-    public BeverageOption(Boolean takeout, SizeType cupSize, EspressoDetail espresso, MilkDetail milk,
+    public BeverageOption(Boolean takeout, Temperature temperature, SizeType cupSize, EspressoDetail espresso, MilkDetail milk,
                           FoamDetail foam, Set<SyrupDetail> syrup, Set<DrizzleDetail> drizzle) {
         this.takeout = takeout;
+        this.temperature = temperature;
         this.cupSize = cupSize;
         this.espresso = espresso;
         this.milk = milk;

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/BeverageOption.java
@@ -68,7 +68,7 @@ public class BeverageOption extends CustomOption {
         if(espresso != null)
             amount += PriceType.ADD_ESPRESSO_SHOT.getPrice() * espresso.getCnt();
 
-        if(milk != null && milk.getType().equals(MilkType.OAT))
+        if(milk != null && milk.getMilkType().equals(MilkType.OAT))
             amount += PriceType.CHANGE_OAT_MILK.getPrice();
 
         if(foam != null)

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -6,10 +6,11 @@ import javax.persistence.*;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name = "TYPE")
+@DiscriminatorColumn
 public abstract class CustomOption {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "custom_option_id")
     private Long id;
 
     @Column(name = "take_out", nullable = false)
@@ -20,7 +21,7 @@ public abstract class CustomOption {
     protected Temperature temperature;
 
     @Column(name = "additional_amount")
-    protected Integer amount = 0;
+    protected int amount = 0;
 
     public abstract int getAdditionalAmount();
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -1,5 +1,7 @@
 package com.devlop.siren.domain.order.domain.option;
 
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
 import javax.persistence.*;
 
 @Entity
@@ -9,22 +11,18 @@ public abstract class CustomOption {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(name = "take_out", nullable = false)
-    private Boolean takeout;
-    @Column(name = "cold", nullable = false)
+    protected Boolean takeout;
+
+    @Column(name = "temperature", nullable = false)
     @Enumerated(EnumType.STRING)
-    private Temperature temperature;
-    @Column(name = "additional_price")
-    private int price = 0;
+    protected Temperature temperature;
 
-    public abstract int getPrice();
-    public void setTemperature(Temperature temperature) {
-        this.temperature = temperature;
-    }
+    @Column(name = "additional_amount")
+    protected Integer amount = 0;
 
-    enum Temperature{
-        HOT, COLD
-    }
+    public abstract int getAdditionalAmount();
 }
 
 

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/CustomOption.java
@@ -1,0 +1,30 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import javax.persistence.*;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "TYPE")
+public abstract class CustomOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "take_out", nullable = false)
+    private Boolean takeout;
+    @Column(name = "cold", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Temperature temperature;
+    @Column(name = "additional_price")
+    private int price = 0;
+
+    public abstract int getPrice();
+    public void setTemperature(Temperature temperature) {
+        this.temperature = temperature;
+    }
+
+    enum Temperature{
+        HOT, COLD
+    }
+}
+
+

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -51,7 +51,7 @@ public class FoodOption extends CustomOption{
     public int getAdditionalAmount() {
         if(potion.size() > 0){
             amount += potion.stream()
-                    .mapToInt(potion -> potion.getType().getPrice() * potion.getCnt())
+                    .mapToInt(potion -> potion.getPotionType().getPrice() * potion.getCnt())
                     .sum();
         }
         return amount;

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -1,0 +1,18 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@DiscriminatorValue("Food")
+@Table(name = "food_options")
+public class FoodOption extends CustomOption{
+    protected FoodOption() {
+        this.setTemperature(CustomOption.Temperature.COLD);
+    }
+    @Override
+    public int getPrice() {
+        return 0;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/FoodOption.java
@@ -1,18 +1,61 @@
 package com.devlop.siren.domain.order.domain.option;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import com.devlop.siren.domain.item.entity.Item;
+import com.devlop.siren.domain.item.entity.option.OptionDetails.*;
+import com.devlop.siren.domain.item.entity.option.OptionTypeGroup.*;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @DiscriminatorValue("Food")
+@NoArgsConstructor
 @Table(name = "food_options")
 public class FoodOption extends CustomOption{
-    protected FoodOption() {
-        this.setTemperature(CustomOption.Temperature.COLD);
+    /*
+    * 추가 옵션 없는 카테고리: 케이크, 샐러드, 아이스크림, 과일, 요거트, 스낵
+    * 포션 옵션 추가되는 카테고리: 브레드
+    * 데움 옵션 추가되는 카테고리: 샌드위치, 브레드, 수프
+    * */
+    @ElementCollection
+    @CollectionTable(name = "potion_details",
+            joinColumns = @JoinColumn(name="custom_option_id"))
+    @Column(name = "potion_type")
+    private Set<PotionDetail> potion = new HashSet<PotionDetail>();
+
+    static Set<String> categoriesWithoutOptions = Set.of("Cake", "Salad", "IceCream", "Fruit", "Yogurt", "Snack");
+    static Set<String> categoriesWithPotionOption = Set.of("Bread");
+    static Set<String> categoriesRequiringWarming = Set.of("Sandwich", "Bread", "Soup");
+
+    @Builder
+    public FoodOption(Item item, Boolean isWarmed, Boolean isTakeOut, Set<PotionDetail> potions) {
+        takeout = isTakeOut;
+
+        String categoryName = item.getCategory().getCategoryName();
+        if(categoriesRequiringWarming.contains(categoryName))
+            temperature = isWarmed ? Temperature.HOT : Temperature.NONE;
+
+        if(categoriesWithoutOptions.contains(categoryName)){
+            temperature = Temperature.NONE;
+        }
+
+        if(categoriesWithPotionOption.contains(categoryName)){
+            potion = potions;
+        }
     }
     @Override
-    public int getPrice() {
-        return 0;
+    public int getAdditionalAmount() {
+        if(potion.size() > 0){
+            amount += potion.stream()
+                    .mapToInt(potion -> potion.getType().getPrice() * potion.getCnt())
+                    .sum();
+        }
+        return amount;
     }
+
+
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
@@ -10,13 +10,13 @@ public enum PriceType {
     ADD_ESPRESSO_SHOT(600),
     ADD_SYRUP(600),
     ADD_DRIZZLE(600),
-    ADD_WHIPPED_CREAM(600)
+    ADD_FOAM(600)
     ;
 
     private int price;
 
-    PriceType(int additionalPrice){
-        this.price = additionalPrice;
+    PriceType(int price){
+        this.price = price;
     }
 
 }

--- a/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
+++ b/src/main/java/com/devlop/siren/domain/order/domain/option/PriceType.java
@@ -1,0 +1,22 @@
+package com.devlop.siren.domain.order.domain.option;
+
+import lombok.Getter;
+
+@Getter
+public enum PriceType {
+    SIZE_UP(500),
+    CHANGE_OAT_MILK(600),
+
+    ADD_ESPRESSO_SHOT(600),
+    ADD_SYRUP(600),
+    ADD_DRIZZLE(600),
+    ADD_WHIPPED_CREAM(600)
+    ;
+
+    private int price;
+
+    PriceType(int additionalPrice){
+        this.price = additionalPrice;
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/request/CustomOptionRequest.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/request/CustomOptionRequest.java
@@ -1,0 +1,58 @@
+package com.devlop.siren.domain.order.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@NoArgsConstructor
+@Getter
+public class CustomOptionRequest {
+    private String cupSize;
+    private String espressoType;
+    private Integer espressoShotCnt;
+    private String milkType;
+    private String milkAmount;
+    private String foamType;
+    private String foamAmount;
+    private Set<SyrupDto> syrups;
+    private Set<DrizzleDto> drizzles;
+
+    private Set<PotionDto> potions;
+
+    @Builder
+    public CustomOptionRequest(String cupSize, String espressoType, Integer espressoShotCnt,
+                               String milkType, String milkAmount, String foamType, String foamAmount,
+                               Set<SyrupDto> syrups, Set<DrizzleDto> drizzles, Set<PotionDto> potions) {
+        this.cupSize = cupSize;
+        this.espressoType = espressoType;
+        this.espressoShotCnt = espressoShotCnt;
+        this.milkType = milkType;
+        this.milkAmount = milkAmount;
+        this.foamType = foamType;
+        this.foamAmount = foamAmount;
+        this.syrups = syrups;
+        this.drizzles = drizzles;
+        this.potions = potions;
+    }
+    @Getter
+    @NoArgsConstructor
+    public static class SyrupDto{
+        String syrupType;
+        int cnt;
+    }
+    @Getter
+    @NoArgsConstructor
+    public static class DrizzleDto{
+        String drizzleType;
+        int cnt;
+    }
+    @Getter
+    @NoArgsConstructor
+    public static class PotionDto{
+        String potionType;
+        int cnt;
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,25 @@
+package com.devlop.siren.domain.order.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderCreateRequest { // 단건 주문
+    @NotNull(message = "매장 아이디가 입력되지 않았습니다")
+    private Long storeId;
+
+    @NotNull(message = "주문아이템이 입력되지 않았습니다")
+    private List<OrderItemRequest> items;
+
+    //TODO :: 결제 카드정보 추가 필요
+
+    public OrderCreateRequest(Long storeId, List<OrderItemRequest> item) {
+        this.storeId = storeId;
+        this.items = item;
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/request/OrderItemRequest.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/request/OrderItemRequest.java
@@ -1,0 +1,22 @@
+package com.devlop.siren.domain.order.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderItemRequest {
+    private Long itemId;
+    private Boolean takeout;
+    private Boolean warm;
+    private int quantity;
+    private CustomOptionRequest customOption;
+
+    public OrderItemRequest(Long itemId, Boolean takeout, Boolean warm, int quantity, CustomOptionRequest customOption) {
+        this.itemId = itemId;
+        this.takeout = takeout;
+        this.warm = warm;
+        this.quantity = quantity;
+        this.customOption = customOption;
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/request/UserRoleChangeRequest.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/request/UserRoleChangeRequest.java
@@ -14,4 +14,9 @@ public class UserRoleChangeRequest {
 
     @NotBlank
     private String roleType;
+
+    public UserRoleChangeRequest(String userEmail, String roleType) {
+        this.userEmail = userEmail;
+        this.roleType = roleType;
+    }
 }

--- a/src/main/java/com/devlop/siren/domain/order/dto/request/UserRoleChangeRequest.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/request/UserRoleChangeRequest.java
@@ -1,0 +1,17 @@
+package com.devlop.siren.domain.order.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@Getter
+public class UserRoleChangeRequest {
+    @NotBlank
+    private String userEmail;
+
+    @NotBlank
+    private String roleType;
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/response/OrderCreateResponse.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/response/OrderCreateResponse.java
@@ -1,0 +1,35 @@
+package com.devlop.siren.domain.order.dto.response;
+
+import com.devlop.siren.domain.order.domain.Order;
+import com.devlop.siren.domain.order.domain.OrderItem;
+import lombok.Builder;
+
+import java.util.List;
+
+public class OrderCreateResponse {
+    private Long orderId;
+    private String storeName;
+    private String storeAddress;
+    private List<OrderItem> items;
+    private int totalCnt;
+    private int totalAmount;
+
+    @Builder
+    public OrderCreateResponse(Long orderId, String storeName, String storeAddress, List<OrderItem> items, int totalCnt, int totalAmount) {
+        this.orderId = orderId;
+        this.storeName = storeName;
+        this.storeAddress = storeAddress;
+        this.items = items;
+        this.totalCnt = totalCnt;
+        this.totalAmount = totalAmount;
+    }
+
+    public static OrderCreateResponse of(Order order){
+        return OrderCreateResponse.builder()
+                .orderId(order.getId())
+                .storeName(order.getStore().getStoreName())
+                .storeAddress(order.getStore().getFullAddress())
+                .items(order.getOrderItems())
+                .build();
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/order/dto/response/OrderReadResponse.java
+++ b/src/main/java/com/devlop/siren/domain/order/dto/response/OrderReadResponse.java
@@ -1,0 +1,4 @@
+package com.devlop.siren.domain.order.dto.response;
+
+public class OrderReadResponse {
+}

--- a/src/main/java/com/devlop/siren/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/devlop/siren/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.devlop.siren.domain.order.repository;
+
+import com.devlop.siren.domain.order.domain.Order;
+import org.springframework.data.repository.CrudRepository;
+
+public interface OrderRepository extends CrudRepository<Order, Long> {
+}

--- a/src/main/java/com/devlop/siren/domain/order/service/OrderService.java
+++ b/src/main/java/com/devlop/siren/domain/order/service/OrderService.java
@@ -1,0 +1,51 @@
+package com.devlop.siren.domain.order.service;
+
+import com.devlop.siren.domain.order.domain.Order;
+import com.devlop.siren.domain.order.domain.OrderItem;
+import com.devlop.siren.domain.order.domain.OrderStatus;
+import com.devlop.siren.domain.order.repository.OrderRepository;
+import com.devlop.siren.domain.store.domain.Store;
+import com.devlop.siren.domain.user.domain.User;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.global.common.response.ResponseCode;
+import com.devlop.siren.global.exception.GlobalException;
+import com.devlop.siren.global.util.UserInformation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+    private final OrderRepository orderRepository;
+    @Transactional
+    public Order create(User user, Store store, List<OrderItem> orderItems){
+        isStoreOperating(store, LocalDateTime.now());
+        Order newOrder = Order.of(user, store, orderItems);
+        return orderRepository.save(newOrder);
+    }
+    private void isStoreOperating(Store store, LocalDateTime now){
+        if(store.getOpenTime().isBefore(now) || store.getCloseTime().isAfter(now)){
+            throw new GlobalException(ResponseCode.ErrorCode.NOT_OPERATING_TIME);
+        }
+    }
+    @Transactional
+    public List<OrderItem> cancel(Long orderId, UserDetailsDto userDto){
+        UserInformation.validStaff(userDto);
+
+        Order order = orderRepository.findById(orderId).orElseThrow(() ->
+                new GlobalException(ResponseCode.ErrorCode.NOT_FOUND_ORDER));
+
+        if(!OrderStatus.INIT.equals(order.getStatus())){
+            throw new GlobalException(ResponseCode.ErrorCode.NOT_CANCEL_ORDER);
+        }
+
+        order.cancel();
+        return order.getOrderItems();
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/order/service/OrderUseCase.java
+++ b/src/main/java/com/devlop/siren/domain/order/service/OrderUseCase.java
@@ -1,0 +1,70 @@
+package com.devlop.siren.domain.order.service;
+
+import com.devlop.siren.domain.item.entity.Item;
+import com.devlop.siren.domain.item.service.ItemService;
+import com.devlop.siren.domain.order.domain.Order;
+import com.devlop.siren.domain.order.domain.OrderItem;
+import com.devlop.siren.domain.order.domain.option.BeverageOption;
+import com.devlop.siren.domain.order.domain.option.CustomOption;
+import com.devlop.siren.domain.order.domain.option.FoodOption;
+import com.devlop.siren.domain.order.dto.request.OrderCreateRequest;
+import com.devlop.siren.domain.order.dto.response.OrderCreateResponse;
+import com.devlop.siren.domain.store.domain.Store;
+import com.devlop.siren.domain.store.service.StoreService;
+import com.devlop.siren.domain.user.domain.User;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OrderUseCase {
+    private final OrderService orderService;
+    private final StoreService storeService;
+    private final ItemService itemService;
+    // private final StockService stock
+
+    public OrderCreateResponse create(OrderCreateRequest request, UserDetailsDto userDto){
+        Store store = storeService.findStore(request.getStoreId());
+        User user = UserDetailsDto.toEntity(userDto);
+        List<OrderItem> orderItems = getOrderItems(request);
+
+        Order createdOrder = orderService.create(user, store, orderItems); // 주문 레파지토리에 저장
+        orderItems.forEach(orderItem -> orderItem.setOrder(createdOrder));
+
+        //TODO :: 카드, 결제 로직
+
+        //TODO :: 주문처리 메시지 큐에 in
+
+        //createdOrder.setQueueInfo(큐타입명, 들어간큐에서몇번째순서인지);
+        return OrderCreateResponse.of(createdOrder);// 새로 만들어진 주문 상태
+    }
+    private List<OrderItem> getOrderItems(OrderCreateRequest request){
+        return request.getItems().stream().map(orderItemRequest -> {
+                    Item item = itemService.findItem(orderItemRequest.getItemId());
+                    //stockService.checkQuantity(item, orderItemRequest.getQuantity()); // 내부에서 수량 부족으로 예외 던지도록
+
+                    CustomOption customOption = null;
+                    switch(item.getCategory().getCategoryType()){
+                        case BEVERAGE:
+                            customOption = BeverageOption.fromDto(orderItemRequest.getCustomOption(), orderItemRequest.getTakeout(), orderItemRequest.getWarm());
+                            break;
+                        case FOOD:
+                            customOption = FoodOption.fromDto(orderItemRequest.getCustomOption(), orderItemRequest.getTakeout(), orderItemRequest.getWarm());
+                    }
+
+                    return OrderItem.create(item, customOption, orderItemRequest.getQuantity());
+                }).collect(Collectors.toList());
+    }
+    public void cancel(Long orderId, UserDetailsDto userDto){
+        List<OrderItem> items = orderService.cancel(orderId, userDto);
+//        items.stream().map( orderItem -> {
+//
+//            //stockService.차감(quantity);
+//        })
+    }
+
+}

--- a/src/main/java/com/devlop/siren/domain/store/domain/Store.java
+++ b/src/main/java/com/devlop/siren/domain/store/domain/Store.java
@@ -1,10 +1,13 @@
 package com.devlop.siren.domain.store.domain;
 
+import com.devlop.siren.domain.order.domain.Order;
 import com.devlop.siren.domain.store.dto.request.StoreUpdateRequest;
 import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -35,6 +38,8 @@ public class Store {
     private Double latitude;
     @Column(name = "longitude", columnDefinition = "NVARCHAR(255) NOT NULL" )
     private Double longitude;
+    @OneToMany(mappedBy = "store")
+    private List<Order> orders = new ArrayList<Order>();
 
     @Builder
     public Store(Long storeId, String storeName, String storePhone, String city, String street,

--- a/src/main/java/com/devlop/siren/domain/user/controller/UserController.java
+++ b/src/main/java/com/devlop/siren/domain/user/controller/UserController.java
@@ -30,9 +30,8 @@ public class UserController {
     private final JwtTokenUtils utils;
 
     @PostMapping
-    public ApiResponse<Void> register(@Valid @RequestBody UserRegisterRequest request){
-        userService.register(request);
-        return ApiResponse.ok(ResponseCode.Normal.CREATE, null);
+    public ApiResponse<UserReadResponse> register(@Valid @RequestBody UserRegisterRequest request){
+        return ApiResponse.ok(ResponseCode.Normal.CREATE, userService.register(request));
     }
 
     @PostMapping("/sessions")

--- a/src/main/java/com/devlop/siren/domain/user/controller/UserController.java
+++ b/src/main/java/com/devlop/siren/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.devlop.siren.domain.user.controller;
 
+import com.devlop.siren.domain.order.dto.request.UserRoleChangeRequest;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.domain.user.dto.UserReadResponse;
 import com.devlop.siren.domain.user.dto.UserTokenDto;
 import com.devlop.siren.domain.user.dto.request.UserLoginRequest;
 import com.devlop.siren.domain.user.dto.request.UserRegisterRequest;
@@ -9,11 +12,14 @@ import com.devlop.siren.global.common.response.ResponseCode;
 import com.devlop.siren.global.util.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @RestController
 @RequestMapping("/api/users")
@@ -50,5 +56,9 @@ public class UserController {
         return ApiResponse.ok(ResponseCode.Normal.UPDATE, token);
     }
 
-
+    @PatchMapping("/role")
+    public ApiResponse<UserReadResponse> changeRole(@Valid @RequestBody UserRoleChangeRequest request,
+                                                    @AuthenticationPrincipal UserDetailsDto userDto){
+        return ApiResponse.ok(ResponseCode.Normal.UPDATE, userService.changeRole(request, userDto));
+    }
 }

--- a/src/main/java/com/devlop/siren/domain/user/domain/User.java
+++ b/src/main/java/com/devlop/siren/domain/user/domain/User.java
@@ -2,6 +2,7 @@ package com.devlop.siren.domain.user.domain;
 //
 import com.devlop.siren.domain.item.entity.AllergyType;
 import com.devlop.siren.domain.item.utils.AllergyConverter;
+import com.devlop.siren.domain.order.domain.Order;
 import com.devlop.siren.domain.user.utils.KoreanNickname;
 import com.devlop.siren.global.common.BaseEntity;
 import lombok.AccessLevel;
@@ -14,7 +15,9 @@ import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -48,6 +51,9 @@ public class User extends BaseEntity {
     @Column(name = "allergy")
     @Convert(converter = AllergyConverter.class)
     private EnumSet<AllergyType> allergies;
+
+    @OneToMany(mappedBy = "user")
+    private List<Order> orders = new ArrayList<Order>();
 
     @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
     private boolean isDeleted;

--- a/src/main/java/com/devlop/siren/domain/user/domain/User.java
+++ b/src/main/java/com/devlop/siren/domain/user/domain/User.java
@@ -29,6 +29,7 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Column(unique = true)

--- a/src/main/java/com/devlop/siren/domain/user/dto/UserReadResponse.java
+++ b/src/main/java/com/devlop/siren/domain/user/dto/UserReadResponse.java
@@ -1,0 +1,32 @@
+package com.devlop.siren.domain.user.dto;
+
+import com.devlop.siren.domain.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@Getter
+public class UserReadResponse {
+    private String email;
+    private String nickName;
+    private String phone;
+    private String userRole;
+    @Builder
+    public UserReadResponse(String email, String nickName, String phone, String userRole) {
+        this.email = email;
+        this.nickName = nickName;
+        this.phone = phone;
+        this.userRole = userRole;
+    }
+    public static UserReadResponse of(User user){
+        return UserReadResponse.builder()
+                .email(user.getEmail())
+                .userRole(user.getRole().getDesc())
+                .nickName(user.getNickName())
+                .phone(user.getPhone())
+                .build();
+    }
+}

--- a/src/main/java/com/devlop/siren/domain/user/service/UserService.java
+++ b/src/main/java/com/devlop/siren/domain/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.devlop.siren.domain.user.service;
 
 import com.devlop.siren.domain.item.utils.AllergyConverter;
+import com.devlop.siren.domain.order.dto.request.UserRoleChangeRequest;
 import com.devlop.siren.domain.user.domain.User;
 import com.devlop.siren.domain.user.domain.UserRole;
 import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.domain.user.dto.UserReadResponse;
 import com.devlop.siren.domain.user.dto.UserTokenDto;
 import com.devlop.siren.domain.user.dto.request.UserLoginRequest;
 import com.devlop.siren.domain.user.dto.request.UserRegisterRequest;
@@ -11,6 +13,7 @@ import com.devlop.siren.domain.user.repository.UserRepository;
 import com.devlop.siren.global.common.response.ResponseCode;
 import com.devlop.siren.global.exception.GlobalException;
 import com.devlop.siren.global.util.JwtTokenUtils;
+import com.devlop.siren.global.util.UserInformation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -88,6 +91,15 @@ public class UserService {
         String newAccessToken = utils.generateAccessToken(userDetail.getEmail(), secretKey, accessExpiredTimeMs);
         utils.setAccessTokenInHeader(newAccessToken, response);
         return newAccessToken;
+    }
+
+    @Transactional
+    public UserReadResponse changeRole(UserRoleChangeRequest request, UserDetailsDto requestUser){
+        UserInformation.validAdmin(requestUser);
+        User user = userRepository.findByEmail(request.getUserEmail()).orElseThrow(() ->
+                new GlobalException(ResponseCode.ErrorCode.NOT_FOUND_MEMBER));
+        user.changeRole(UserRole.valueOf(request.getRoleType()));
+        return UserReadResponse.of(user);
     }
 
     private void checkPassword(String request, String password){

--- a/src/main/java/com/devlop/siren/domain/user/service/UserService.java
+++ b/src/main/java/com/devlop/siren/domain/user/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
     }
 
     @Transactional
-    public void register(UserRegisterRequest request) {
+    public UserReadResponse register(UserRegisterRequest request) {
         userRepository.findByEmail(request.getEmail()).ifPresent(user -> {
             throw new GlobalException(ResponseCode.ErrorCode.DUPLICATED_MEMBER);
         });
@@ -57,7 +57,7 @@ public class UserService {
         User entity = UserRegisterRequest.fromDto(request, encoder.encode(request.getPassword()),
                 UserRole.CUSTOMER, converter.convertToEntityAttribute(request.getAllergies()));
 
-        userRepository.save(entity);
+        return UserReadResponse.of(userRepository.save(entity));
     }
 
     @Transactional

--- a/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/devlop/siren/item/controller/ItemControllerTest.java
@@ -6,7 +6,7 @@ import com.devlop.siren.domain.item.controller.ItemController;
 import com.devlop.siren.domain.item.dto.request.DefaultOptionCreateRequest;
 import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
 import com.devlop.siren.domain.item.dto.request.NutritionCreateRequest;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import com.devlop.siren.domain.item.service.ItemService;
 import com.devlop.siren.domain.user.dto.UserDetailsDto;
 import com.devlop.siren.global.util.UserInformation;

--- a/src/test/java/com/devlop/siren/item/service/ItemServiceImplTest.java
+++ b/src/test/java/com/devlop/siren/item/service/ItemServiceImplTest.java
@@ -9,7 +9,7 @@ import com.devlop.siren.domain.item.dto.request.ItemCreateRequest;
 import com.devlop.siren.domain.item.dto.request.NutritionCreateRequest;
 import com.devlop.siren.domain.item.entity.AllergyType;
 import com.devlop.siren.domain.item.entity.Item;
-import com.devlop.siren.domain.item.entity.SizeType;
+import com.devlop.siren.domain.item.entity.option.SizeType;
 import com.devlop.siren.domain.item.repository.DefaultOptionRepository;
 import com.devlop.siren.domain.item.repository.ItemRepository;
 import com.devlop.siren.domain.item.repository.NutritionRepository;

--- a/src/test/java/com/devlop/siren/user/controller/UserControllerTest.java
+++ b/src/test/java/com/devlop/siren/user/controller/UserControllerTest.java
@@ -1,6 +1,9 @@
 package com.devlop.siren.user.controller;
 
+import com.devlop.siren.domain.order.dto.request.UserRoleChangeRequest;
 import com.devlop.siren.domain.user.controller.UserController;
+import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.domain.user.dto.UserReadResponse;
 import com.devlop.siren.domain.user.dto.UserTokenDto;
 import com.devlop.siren.domain.user.dto.request.UserLoginRequest;
 import com.devlop.siren.domain.user.dto.request.UserRegisterRequest;
@@ -198,6 +201,32 @@ public class UserControllerTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("관리자가 요청한 정보로 유저 권한을 수정한다")
+    @WithMockUser
+    void changeRole() throws Exception {
+        UserRoleChangeRequest request = new UserRoleChangeRequest("test@test.com", "STAFF");
+        when(userService.changeRole(request, mock(UserDetailsDto.class))).thenReturn(mock(UserReadResponse.class));
+        mockMvc.perform(patch("/api/users/role")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유저 권한 변경 시 필수 요청값이 없어 예외가 발생한다")
+    @WithMockUser
+    void changeRoleWithNotRequest() throws Exception {
+        UserLoginRequest request = new UserLoginRequest("test@test.com", "");
+        mockMvc.perform(patch("/api/users/role")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isBadRequest())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## 🎯 What is this PR
> 초기 회원가입 시 세팅되는 유저의 롤은 CUSTOMER이나, Admin이 변경할 유저 email과 변경할 유저 롤을 요청하면 변경할 수 있음

## 📄 Changes Made
- UserController에 PATCH API  /api/users/role 추가
- Request로 userEmai과 role 요청
- Service에서 validAdmin으로 요청 유저의 권한 확인
- 기존 회원가입 응답 시 void로 리턴했었는데 UserReadResponse 객체를 응답하는 것으로 변경함 

## 📸 Screenshot
> 유저 변경 테스트 
<img width="463" alt="image" src="https://github.com/Siren-repo/Siren/assets/35358294/740da72d-2eed-4fcb-9a7e-3fa614c38de0">

회원가입 응답객체 void에서 UserReadResponse 객체로 변경 
<img width="446" alt="image" src="https://github.com/Siren-repo/Siren/assets/35358294/d466b540-b3cc-4421-a3f4-2bee6d9527c6">

## 🙋🏻‍ Review Point
- admin이 요청한 user의 email, role로 변경하는 로직 확인 
- 더 발생할 예외사항이 있는지 

## ✅ Test Checklist
- [ ] UserControllerTest- 롤 변경 성공테스트 
- [ ] UserControllerTest - request dto 필수값 없을 시 bad request 확인
- [ ] UserServiceTest - 변경 성공테스트 
- [ ] UserServiceTest - admin으로 요청하지 않았을 경우 unauthorize 확인

## 🔗 Reference
Issue #5