### PR TITLE
리플리케이션 적용

### DIFF
--- a/src/main/java/com/devlop/siren/SirenApplication.java
+++ b/src/main/java/com/devlop/siren/SirenApplication.java
@@ -2,6 +2,7 @@ package com.devlop.siren;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 public class SirenApplication {

--- a/src/main/java/com/devlop/siren/SirenApplication.java
+++ b/src/main/java/com/devlop/siren/SirenApplication.java
@@ -2,7 +2,6 @@ package com.devlop.siren;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 public class SirenApplication {

--- a/src/main/java/com/devlop/siren/global/configuration/db/DataSourceConstants.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/DataSourceConstants.java
@@ -1,0 +1,6 @@
+package com.devlop.siren.global.configuration.db;
+
+public class DataSourceConstants {
+    public static final String MASTER = "master";
+    public static final String SLAVE = "slave";
+}

--- a/src/main/java/com/devlop/siren/global/configuration/db/DataSourceConstants.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/DataSourceConstants.java
@@ -1,6 +1,6 @@
 package com.devlop.siren.global.configuration.db;
 
 public class DataSourceConstants {
-    public static final String MASTER = "master";
-    public static final String SLAVE = "slave";
+  public static final String MASTER = "master";
+  public static final String SLAVE = "slave";
 }

--- a/src/main/java/com/devlop/siren/global/configuration/db/DynamicRoutingDataSource.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/DynamicRoutingDataSource.java
@@ -1,0 +1,17 @@
+package com.devlop.siren.global.configuration.db;
+
+import static com.devlop.siren.global.configuration.db.DataSourceConstants.MASTER;
+import static com.devlop.siren.global.configuration.db.DataSourceConstants.SLAVE;
+import static org.springframework.transaction.support.TransactionSynchronizationManager.isCurrentTransactionReadOnly;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+@Slf4j
+public class DynamicRoutingDataSource extends AbstractRoutingDataSource {
+
+  @Override
+  protected Object determineCurrentLookupKey() {
+    return isCurrentTransactionReadOnly() ? SLAVE : MASTER;
+  }
+}

--- a/src/main/java/com/devlop/siren/global/configuration/db/MasterDataSourceConfig.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/MasterDataSourceConfig.java
@@ -1,0 +1,21 @@
+package com.devlop.siren.global.configuration.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@Slf4j
+public class MasterDataSourceConfig {
+  @Primary
+  @Bean(name = "masterDataSource")
+  @ConfigurationProperties(prefix = "spring.datasource.master")
+  public DataSource masterDataSource() {
+    return DataSourceBuilder.create().type(HikariDataSource.class).build();
+  }
+}

--- a/src/main/java/com/devlop/siren/global/configuration/db/RoutingDataSourceConfig.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/RoutingDataSourceConfig.java
@@ -1,0 +1,41 @@
+package com.devlop.siren.global.configuration.db;
+
+import static com.devlop.siren.global.configuration.db.DataSourceConstants.MASTER;
+import static com.devlop.siren.global.configuration.db.DataSourceConstants.SLAVE;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class RoutingDataSourceConfig {
+
+  @DependsOn({"masterDataSource", "slaveDataSource"})
+  @Bean(name = "routingDataSource")
+  public DataSource routingDataSource(
+      @Qualifier("masterDataSource") DataSource master,
+      @Qualifier("slaveDataSource") DataSource slave) {
+    DynamicRoutingDataSource routingDataSource = new DynamicRoutingDataSource();
+
+    Map<Object, Object> dataSourceMap = new HashMap<>();
+
+    dataSourceMap.put(MASTER, master);
+    dataSourceMap.put(SLAVE, slave);
+
+    routingDataSource.setTargetDataSources(dataSourceMap);
+    routingDataSource.setDefaultTargetDataSource(master);
+
+    return routingDataSource;
+  }
+
+  @DependsOn({"routingDataSource"})
+  @Bean(name = "dataSource")
+  public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+    return new LazyConnectionDataSourceProxy(routingDataSource);
+  }
+}

--- a/src/main/java/com/devlop/siren/global/configuration/db/SlaveDataSourceConfig.java
+++ b/src/main/java/com/devlop/siren/global/configuration/db/SlaveDataSourceConfig.java
@@ -1,0 +1,20 @@
+package com.devlop.siren.global.configuration.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class SlaveDataSourceConfig {
+
+  @Bean(name = "slaveDataSource")
+  @ConfigurationProperties(prefix = "spring.datasource.slave")
+  public DataSource slaveDataSource() {
+    return DataSourceBuilder.create().type(HikariDataSource.class).build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,16 +44,39 @@ spring:
       host: ${CART_REDIS_HOST}
       port: ${CART_REDIS_PORT}
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DATASOURCE_IP}:${DATASOURCE_PORT}/${DATASOURCE_DATABASE}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-    username: ${DATASOURCE_USERNAME}
-    password: ${DATASOURCE_PASSWORD}
+    master:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: jdbc:mysql://${DATASOURCE_IP}:${DATASOURCE_MASTER_PORT}/${DATASOURCE_DATABASE}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+      username: ${DATASOURCE_USERNAME}
+      password: ${DATASOURCE_PASSWORD}
+      read-only: false
+    slave:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: jdbc:mysql://${DATASOURCE_IP}:${DATASOURCE_SLAVE_PORT}/${DATASOURCE_DATABASE}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+      username: ${DATASOURCE_USERNAME}
+      password: ${DATASOURCE_PASSWORD}
+      read-only: true
   jpa:
     database: MYSQL
     hibernate:
       ddl-auto: update
-    show-sql: true
+      naming:
+        physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
     database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE
+
+
 ---
 
 spring:

--- a/src/test/java/com/devlop/siren/fixture/OrderFixture.java
+++ b/src/test/java/com/devlop/siren/fixture/OrderFixture.java
@@ -89,7 +89,7 @@ public class OrderFixture {
             .city("Seoul")
             .storeName("강남대로신사")
             .street("서울특별시 서초구 강남대로 595")
-            .zipCode(12345)
+            .zipCode("12345")
             .latitude(37.5148446)
             .storePhone("1522-3232")
             .longitude(127.0194574)

--- a/src/test/java/com/devlop/siren/global/configuration/db/DynamicRoutingDataSourceTest.java
+++ b/src/test/java/com/devlop/siren/global/configuration/db/DynamicRoutingDataSourceTest.java
@@ -1,0 +1,64 @@
+package com.devlop.siren.global.configuration.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+@SpringBootTest
+class DynamicRoutingDataSourceTest {
+  @Autowired private Environment environment;
+
+  @Test
+  @DisplayName("Master_DataSource_테스트")
+  void masterDataSourceTest(@Qualifier("masterDataSource") final DataSource masterDataSource) {
+    // given
+    String url = environment.getProperty("spring.datasource.master.jdbc-url");
+    String username = environment.getProperty("spring.datasource.master.username");
+    String driverClassName = environment.getProperty("spring.datasource.master.driver-class-name");
+    Boolean readOnly =
+        Boolean.valueOf(environment.getProperty("spring.datasource.master.read-only"));
+
+    // when
+    HikariDataSource hikariDataSource = (HikariDataSource) masterDataSource;
+
+    // then
+    verifyOf(readOnly, url, username, driverClassName, hikariDataSource);
+  }
+
+  @Test
+  @DisplayName("Slave_DataSource_테스트")
+  void slaveDataSourceTest(@Qualifier("slaveDataSource") final DataSource slaveDataSource) {
+    // given
+    String url = environment.getProperty("spring.datasource.slave.jdbc-url");
+    String username = environment.getProperty("spring.datasource.slave.username");
+    String driverClassName = environment.getProperty("spring.datasource.slave.driver-class-name");
+    Boolean readOnly =
+        Boolean.valueOf(environment.getProperty("spring.datasource.slave.read-only"));
+
+    // when
+    HikariDataSource hikariDataSource = (HikariDataSource) slaveDataSource;
+
+    // then
+    verifyOf(readOnly, url, username, driverClassName, hikariDataSource);
+  }
+
+  private void verifyOf(
+      Boolean readOnly,
+      String url,
+      String username,
+      String driverClassName,
+      HikariDataSource hikariDataSource) {
+    assertThat(hikariDataSource.isReadOnly()).isEqualTo(readOnly);
+    assertThat(hikariDataSource.getJdbcUrl()).isEqualTo(url);
+    assertThat(hikariDataSource.getUsername()).isEqualTo(username);
+    assertThat(hikariDataSource.getDriverClassName()).isEqualTo(driverClassName);
+  }
+}

--- a/src/test/java/com/devlop/siren/global/configuration/db/RoutingDataSourceConfigTest.java
+++ b/src/test/java/com/devlop/siren/global/configuration/db/RoutingDataSourceConfigTest.java
@@ -1,0 +1,56 @@
+package com.devlop.siren.global.configuration.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class RoutingDataSourceConfigTest {
+  private static final String Test_Method_Name = "determineCurrentLookupKey";
+
+  @Test
+  @DisplayName("쓰기_전용_트랜잭션_테스트")
+  @Transactional(readOnly = false)
+  void writeOnlyTransactionTest()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    // given
+    DynamicRoutingDataSource dynamicRoutingDataSource = new DynamicRoutingDataSource();
+
+    // when
+    Method determineCurrentLookupKey =
+        DynamicRoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+    determineCurrentLookupKey.setAccessible(true);
+
+    Object dataSourceType = determineCurrentLookupKey.invoke(dynamicRoutingDataSource);
+
+    // then
+    assertThat(dataSourceType).isEqualTo(DataSourceConstants.MASTER);
+  }
+
+  @Test
+  @DisplayName("읽기_전용_트랜잭션_테스트")
+  @Transactional(readOnly = true)
+  void readOnlyTransactionTest()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    // given
+    DynamicRoutingDataSource dynamicRoutingDataSource = new DynamicRoutingDataSource();
+
+    // when
+    Method determineCurrentLookupKey =
+        DynamicRoutingDataSource.class.getDeclaredMethod(Test_Method_Name);
+    determineCurrentLookupKey.setAccessible(true);
+
+    Object dataSourceType = determineCurrentLookupKey.invoke(dynamicRoutingDataSource);
+
+    // then
+    assertThat(dataSourceType).isEqualTo(DataSourceConstants.SLAVE);
+  }
+}

--- a/src/test/java/com/devlop/siren/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/devlop/siren/order/controller/OrderControllerTest.java
@@ -48,7 +48,7 @@ public class OrderControllerTest {
   private OrderCreateRequest validOrderCreateRequest;
 
   @BeforeEach
-  void init() {
+  void init() throws NoSuchFieldException, IllegalAccessException {
     store = OrderFixture.get(LocalTime.of(9, 00), LocalTime.of(18, 00));
     orderItemRequest = OrderFixture.getOrderItemRequest();
     validOrderCreateRequest = OrderFixture.get(store.getStoreId(), orderItemRequest);

--- a/src/test/java/com/devlop/siren/order/service/OrderUseCaseTest.java
+++ b/src/test/java/com/devlop/siren/order/service/OrderUseCaseTest.java
@@ -60,7 +60,7 @@ public class OrderUseCaseTest {
   @Test
   @DisplayName("요청한 request대로 주문을 생성한다 - 음료")
   void createOrder() throws NoSuchFieldException, IllegalAccessException {
-    Item item = ItemFixture.get();
+    Item item = ItemFixture.get(1L);
     Field field = Item.class.getDeclaredField("itemId");
     field.setAccessible(true);
     field.set(item, 1L);

--- a/src/test/java/com/devlop/siren/store/service/StoreServiceTest.java
+++ b/src/test/java/com/devlop/siren/store/service/StoreServiceTest.java
@@ -13,6 +13,7 @@ import com.devlop.siren.domain.store.repository.StoreRepository;
 import com.devlop.siren.domain.store.service.StoreService;
 import com.devlop.siren.domain.store.utils.GeocodingApi;
 import com.devlop.siren.domain.user.dto.UserDetailsDto;
+import com.devlop.siren.fixture.StoreFixture;
 import com.devlop.siren.global.exception.GlobalException;
 import com.google.maps.errors.ApiException;
 import com.google.maps.model.GeocodingResult;
@@ -44,7 +45,7 @@ class StoreServiceTest {
   @Mock private UserDetailsDto customer;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws NoSuchFieldException, IllegalAccessException {
     registerRequest =
         new StoreRegisterRequest(
             "First Store Name",


### PR DESCRIPTION
## 🎯 What is this PR

Master/Slave구조의 리플리케이션 적용

### 리플리케이션을 적용하는 이유 3가지
- **데이터 안정성 및 복구**: 주 데이터베이스에 문제가 발생했을 때, 슬레이브 데이터베이스를 사용하여 데이터를 복구하고 서비스의 연속성을 유지할 수 있습니다.
- **부하 분산**: **해당 프로젝트의 경우 쓰기 쿼리보다는 읽기 쿼리에 빈도가 더 높다고 판단되어**, 읽기 쿼리를 슬레이브 데이터베이스로 전송하여 마스터 데이터베이스의 부하를 줄일 수 있습니다. 이는 전체 시스템의 읽기 성능을 향상시키는 기대를 불러일으킵니다.
- **백업**: 실시간 또는 거의 실시간으로 데이터를 복제함으로써 지속적인 백업이 이루어집니다.


## 📄 Changes Made

새로운 EC2서버`(ip : 3.35.156.24)`를 구축하여 해당 서버의 docker 컨테이너를 2개 띄워 하나는 `Master DB`, 하나는 `Slave DB` 로 구성하여,
읽기 요청에 대한 부하를 분산시켜 전체 성능 향상을 도모

## 📸 Screenshot

![image](https://github.com/Siren-repo/Siren/assets/98626972/8a845fa7-c2e3-4987-9a61-d7512fdf892f)


### 성능 평가
- 요청을 보내는 사용자의 수 : `1000명`
- 요청을 보내는 시간간격 : `0초`
- 반복 횟수 : `10`
위와 같이 설정했을 경우 아래와 같은 `TPS`를 갖게 되었고, 전체적으로 `TPS`가 높은것은 **리플리케이션 적용 후**로 보이며, 간혹 보이는 트랜잭션처리 수가 극도로 빠지는 구간은 로컬에서 테스트를 한것이기 때문에 보여지지, 특정되지 않은 예외사항들이 많을것으로 추측됩니다.
네트워크 상의 예외도 간과할 수 없는 문제로 판단되지만, 전체적인 평균을 바라봤을 때 **리플리케이션 적용**을 하고 난 후에 `TPS`가 더 높은것으로 보여집니다.

<img width="550" alt="image" src="https://github.com/Siren-repo/Siren/assets/98626972/0c4c1e5a-47b4-4a00-acf8-1a62b065b4f2">


> Replication 적용 후

![image](https://github.com/Siren-repo/Siren/assets/98626972/18711177-ed72-4c82-993b-6917f95760b6)


> Replication 적용 전

![image](https://github.com/Siren-repo/Siren/assets/98626972/709fecea-a77c-4069-9722-ba0c2b55bc15)


## 🙋🏻‍ Review Point
- 1개 이상의 `Datasource` 를 정의하면 스프링 부트에서 제공하는 `AutoConfiguration` 도움은 받을 수 없게 됩니다.
그렇기 때문에 `Master/Slave Datasource` 를 코드로 설정해줘야 합니다.
- `TransactionSynchronizationManager` 를 통해 `Read / Write`  타입을 판별 후 `Datasource Type`을 반환합니다.
- `RoutingDataSourceConfig` 클래스에서는 `LazyConnectionDataSourceProxy` 객체를 사용하는 것을 볼 수 있습니다.
- 스프링에서는 `Transaction` 생성 시점에 `Datasource Connection` 을 가져오기 때문에, 
항상 `@Primary` 가 붙은 `Master Data` 를 가져오게 될 것 입니다.
따라서 `Transaction` 생성 시점이 아닌 실제로 쿼리가 발생하는 시점에 `Datasource Connection` 을 가져오기 위해서 
`LazyConnectionDataSourceProxy` 을 사용하였습니다

## ✅ Test Checklist

- [x] `DataSource`를 정상적으로 생성하는지
- [x] `Read/Write`에 따른 `DataSource` 분기


## 🔗 Reference

Issue #48 